### PR TITLE
Add sitemap, robots.txt and crawl directives

### DIFF
--- a/app/about-me/page.js
+++ b/app/about-me/page.js
@@ -6,6 +6,9 @@ import MagneticButton from "../components/motion/MagneticButton";
 export const metadata = {
   title: "About Me - Sarthaksavvy",
   description: "Get to know Sarthak Shrivastava's journey in tech.",
+  alternates: {
+    canonical: "https://sarthaksavvy.com/about-me",
+  },
 };
 
 const currentRoles = [

--- a/app/ask/layout.js
+++ b/app/ask/layout.js
@@ -1,0 +1,13 @@
+// The answers on this page are generated per `?q=` query, so every search
+// would become its own thin, near-duplicate URL. Keep it out of the index
+// while leaving it fully usable for visitors.
+export const metadata = {
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+export default function AskLayout({ children }) {
+  return children;
+}

--- a/app/robots.js
+++ b/app/robots.js
@@ -1,0 +1,13 @@
+import { SITE_URL, disallowedPaths } from "./routes";
+
+export default function robots() {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: disallowedPaths,
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,0 +1,19 @@
+export const SITE_URL = "https://sarthaksavvy.com";
+
+// Single source of truth for the site's indexable routes. Used by the
+// sitemap so a new page only has to be registered in one place.
+export const indexableRoutes = [
+  { path: "/", changeFrequency: "monthly", priority: 1 },
+  { path: "/about-me", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/side-projects", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/podcasts", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/public-speaking", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/side-projects/ginger", changeFrequency: "yearly", priority: 0.6 },
+  { path: "/side-projects/expensorr", changeFrequency: "yearly", priority: 0.6 },
+  { path: "/side-projects/mezohub", changeFrequency: "yearly", priority: 0.6 },
+];
+
+// Routes kept out of search results: the API and the /ask tool, whose
+// answers are generated per `?q=` and would otherwise open an unbounded
+// space of thin, near-duplicate URLs to crawlers.
+export const disallowedPaths = ["/api/", "/ask"];

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,0 +1,12 @@
+import { SITE_URL, indexableRoutes } from "./routes";
+
+export default function sitemap() {
+  const lastModified = new Date();
+
+  return indexableRoutes.map(({ path, changeFrequency, priority }) => ({
+    url: `${SITE_URL}${path === "/" ? "" : path}`,
+    lastModified,
+    changeFrequency,
+    priority,
+  }));
+}


### PR DESCRIPTION
## What changed

The site had no `sitemap.xml` and no `robots.txt` at all. Search engines had to discover every page by following links, and there were no crawl directives of any kind.

| File | Change |
|---|---|
| `app/routes.js` | **New** — single source of truth for indexable routes and the disallow list |
| `app/sitemap.js` | **New** — generates `/sitemap.xml` from that list |
| `app/robots.js` | **New** — generates `/robots.txt`, points at the sitemap |
| `app/ask/layout.js` | **New** — `noindex, follow` on `/ask` (the page is `"use client"`, so metadata needs a layout) |
| `app/about-me/page.js` | Added the `alternates.canonical` that every other route already had |

## Why it helps

- **Crawl coverage.** A submitted sitemap gives Google an explicit list of the 8 canonical URLs with `lastmod` and priority, instead of relying on link discovery from the nav.
- **Crawl budget.** `/ask` generates its answer per `?q=` parameter, so without a directive every distinct search becomes its own thin, near-duplicate indexable URL — an unbounded space for crawlers to wander. `noindex, follow` keeps the page fully usable for visitors while keeping it out of the index and still passing link equity.
- **Canonical consistency.** `/about-me` was the one route missing a canonical, leaving it open to duplicate-URL ambiguity.

Routes are registered in one place (`app/routes.js`) so a new page only has to be added once for the sitemap to pick it up.

## Build and lint status

- `npm ci` → `npm run build` **passes**. The route table now lists `/robots.txt` and `/sitemap.xml`.
- Verified the generated output rather than trusting the build alone: `robots.txt` carries the correct `Disallow` / `Sitemap` / `Host` lines, `sitemap.xml` lists all 8 routes, `/ask` renders `<meta name="robots" content="noindex, follow"/>`, and `/about-me` renders its canonical link.
- `npm run lint` reports 5 **pre-existing** errors in `app/side-projects/expensorr/page.js` and `app/side-projects/ginger/page.js` (unescaped entities). Both files are untouched by this PR; the new files are lint-clean.

## TODO placeholders

None.

## Scope

No visible copy, layout, or dependency changes — metadata plumbing only. No new dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNfiWT7LbA8XiVKhdj8qvc)_