### PR TITLE
Fix broken share previews and centralise page metadata

### DIFF
--- a/app/about-me/page.js
+++ b/app/about-me/page.js
@@ -2,14 +2,13 @@ import Image from "next/image";
 import Reveal from "../components/motion/Reveal";
 import { StaggerGroup, StaggerItem } from "../components/motion/Stagger";
 import MagneticButton from "../components/motion/MagneticButton";
+import { pageMetadata } from "../seo";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "About Me - Sarthaksavvy",
   description: "Get to know Sarthak Shrivastava's journey in tech.",
-  alternates: {
-    canonical: "https://sarthaksavvy.com/about-me",
-  },
-};
+  path: "/about-me",
+});
 
 const currentRoles = [
   "Founder of Bitfumes",
@@ -99,7 +98,7 @@ const AboutPage = () => {
         <div className="mb-24">
           <Reveal>
             <h2 className="text-xs font-mono uppercase tracking-[0.3em] text-muted mb-8">
-              // Professional Journey
+              {"// Professional Journey"}
             </h2>
           </Reveal>
           <StaggerGroup className="grid md:grid-cols-2 gap-8">
@@ -115,7 +114,7 @@ const AboutPage = () => {
         <div className="mb-24">
           <Reveal>
             <h2 className="text-xs font-mono uppercase tracking-[0.3em] text-muted mb-8">
-              // Achievements
+              {"// Achievements"}
             </h2>
           </Reveal>
           <StaggerGroup className="grid md:grid-cols-2 gap-8 mb-8">

--- a/app/components/EntryGate.js
+++ b/app/components/EntryGate.js
@@ -101,7 +101,7 @@ export default function EntryGate() {
             transition={{ duration: 0.5, delay: 0.1 }}
           >
             <p className="font-mono text-xs tracking-[0.3em] text-muted mb-4">
-              // SYSTEM · SARTHAKSAVVY.EXE
+              {"// SYSTEM · SARTHAKSAVVY.EXE"}
             </p>
             <h1 className="font-display text-3xl sm:text-5xl italic mb-4">
               initializing portfolio

--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -22,7 +22,7 @@ export default function Footer() {
         <div className="flex flex-col md:flex-row justify-between gap-10 mb-16">
           <div>
             <p className="font-mono text-xs tracking-widest text-muted mb-3">
-              // LET&apos;S BUILD SOMETHING
+              {"// LET'S BUILD SOMETHING"}
             </p>
             <a
               href="mailto:hello@sarthaksavvy.com"

--- a/app/layout.js
+++ b/app/layout.js
@@ -5,6 +5,8 @@ import Footer from "./components/Footer";
 import FloatingChatWidget from "./components/FloatingChatWidget";
 import EntryGate from "./components/EntryGate";
 import ResetIntroButton from "./components/ResetIntroButton";
+import { SITE_URL } from "./routes";
+import { SITE_NAME, ogImages } from "./seo";
 import "./globals.css";
 
 const geistSans = localFont({
@@ -27,10 +29,29 @@ const fraunces = Fraunces({
   display: "swap",
 });
 
+// Site-wide fallback. Routes that set their own metadata override these; the
+// point here is that a route which forgets to still shares with a working
+// card instead of a bare link. No canonical is set at this level — it would be
+// inherited by every page that does not declare one and point them all at "/".
 export const metadata = {
   title: "Sarthak Shrivastava - Sarthaksavvy",
   description: "Sarthak Shrivastava's personal website",
-  metadataBase: new URL("https://sarthaksavvy.com"),
+  metadataBase: new URL(SITE_URL),
+  openGraph: {
+    type: "website",
+    title: "Sarthak Shrivastava - Sarthaksavvy",
+    description: "Sarthak Shrivastava's personal website",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    locale: "en_US",
+    images: [ogImages.portrait],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Sarthak Shrivastava - Sarthaksavvy",
+    description: "Sarthak Shrivastava's personal website",
+    images: [ogImages.portrait.url],
+  },
 };
 
 export default function RootLayout({ children }) {

--- a/app/page.js
+++ b/app/page.js
@@ -1,20 +1,12 @@
 import Hero from "./components/Hero";
 import Marquee from "./components/Marquee";
+import { pageMetadata } from "./seo";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Sarthaksavvy",
   description: "Sarthak Shrivastava's personal website",
-  alternates: {
-    canonical: "https://sarthaksavvy.com",
-  },
-  openGraph: {
-    title: "Sarthak Shrivastava - Sarthaksavvy",
-    description: "Sarthak Shrivastava's personal website",
-    url: "https://sarthaksavvy.com",
-    siteName: "Sarthak Shrivastava - Sarthaksavvy",
-    images: "/sarthak.jpg",
-  },
-};
+  path: "/",
+});
 
 export default function Home() {
   return (

--- a/app/podcasts/page.js
+++ b/app/podcasts/page.js
@@ -3,21 +3,14 @@ import Image from "next/image";
 import Reveal from "../components/motion/Reveal";
 import MagneticButton from "../components/motion/MagneticButton";
 import TiltCard from "../components/motion/TiltCard";
+import { ogImages, pageMetadata } from "../seo";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Podcasts",
   description: "Podcasts by Sarthak Shrivastava",
-  alternates: {
-    canonical: "https://sarthaksavvy.com/podcasts",
-  },
-  openGraph: {
-    title: "Sarthak Shrivastava - Podcasts",
-    description: "Podcasts by Sarthak Shrivastava",
-    url: "https://sarthaksavvy.com/podcasts",
-    siteName: "Sarthak Shrivastava - Podcasts",
-    images: "/laravel-india-podcast.png",
-  },
-};
+  path: "/podcasts",
+  image: ogImages.podcast,
+});
 
 const platforms = [
   {

--- a/app/public-speaking/page.js
+++ b/app/public-speaking/page.js
@@ -3,21 +3,13 @@ import SingleEvent from "../components/PublicSpeaking/SingleEvent";
 import speakingEvents from "../events.json";
 import Reveal from "../components/motion/Reveal";
 import MagneticButton from "../components/motion/MagneticButton";
+import { pageMetadata } from "../seo";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Public Speaking",
   description: "Public Speaking by Sarthak Shrivastava",
-  alternates: {
-    canonical: "https://sarthaksavvy.com/public-speaking",
-  },
-  openGraph: {
-    title: "Sarthak Shrivastava - Public Speaking",
-    description: "Public Speaking by Sarthak Shrivastava",
-    url: "https://sarthaksavvy.com/public-speaking",
-    siteName: "Sarthak Shrivastava - Public Speaking",
-    images: "/sarthak.jpg",
-  },
-};
+  path: "/public-speaking",
+});
 
 export default function SpeakingTimeline() {
   return (

--- a/app/routes.js
+++ b/app/routes.js
@@ -8,6 +8,8 @@ export const indexableRoutes = [
   { path: "/side-projects", changeFrequency: "monthly", priority: 0.8 },
   { path: "/podcasts", changeFrequency: "monthly", priority: 0.7 },
   { path: "/public-speaking", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/side-projects/backstage-cut", changeFrequency: "yearly", priority: 0.6 },
+  { path: "/side-projects/audiobolo", changeFrequency: "yearly", priority: 0.6 },
   { path: "/side-projects/ginger", changeFrequency: "yearly", priority: 0.6 },
   { path: "/side-projects/expensorr", changeFrequency: "yearly", priority: 0.6 },
   { path: "/side-projects/mezohub", changeFrequency: "yearly", priority: 0.6 },

--- a/app/seo.js
+++ b/app/seo.js
@@ -1,0 +1,104 @@
+import { SITE_URL } from "./routes";
+
+export const SITE_NAME = "Sarthak Shrivastava";
+
+// Share previews are easy to get subtly wrong: the image has to resolve from
+// the site root, the canonical has to match the sitemap entry, and Twitter
+// needs its own tags because it does not read the OpenGraph ones. Building all
+// of that from one place keeps every route consistent and makes a broken image
+// path a one-line fix instead of an eight-file one.
+
+// Every image below lives in /public/images. Dimensions are the real ones, so
+// crawlers can lay the card out before the file finishes downloading.
+export const ogImages = {
+  portrait: {
+    url: "/images/sarthak.jpg",
+    width: 2668,
+    height: 2773,
+    alt: "Sarthak Shrivastava",
+  },
+  podcast: {
+    url: "/images/laravel-india-podcast.png",
+    width: 3000,
+    height: 3000,
+    alt: "Laravel India Podcast cover art",
+  },
+  audiobolo: {
+    url: "/images/projects/audiobolo.png",
+    width: 1200,
+    height: 630,
+    alt: "AudioBolo, an AI voice-to-text app for macOS",
+  },
+  backstageCut: {
+    url: "/images/projects/backstage-cut.png",
+    width: 1200,
+    height: 630,
+    alt: "Backstage Cut, an AI extension for Premiere Pro",
+  },
+  expensorr: {
+    url: "/images/projects/expensorr.png",
+    width: 1200,
+    height: 630,
+    alt: "Expensorr, an expense tracking app",
+  },
+  ginger: {
+    url: "/images/projects/ginger.jpg",
+    width: 400,
+    height: 400,
+    alt: "Ginger, a LinkedIn AI assistant Chrome extension",
+  },
+  mezohub: {
+    url: "/images/projects/mezohub.jpg",
+    width: 1563,
+    height: 1563,
+    alt: "Mezohub, a backend deployment platform",
+  },
+};
+
+// A wide card needs an image X will actually accept at that size; anything
+// smaller renders better as the compact card than as a stretched banner.
+function twitterCard(image) {
+  return image.width >= 600 ? "summary_large_image" : "summary";
+}
+
+export function canonicalUrl(path = "/") {
+  return `${SITE_URL}${path === "/" ? "" : path}`;
+}
+
+/**
+ * Builds the canonical, OpenGraph and Twitter metadata for a route.
+ * `path` must match the route registered in routes.js so the canonical URL
+ * and the sitemap entry never drift apart.
+ */
+export function pageMetadata({
+  title,
+  description,
+  path = "/",
+  image = ogImages.portrait,
+  type = "website",
+}) {
+  const url = canonicalUrl(path);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      type,
+      title,
+      description,
+      url,
+      siteName: SITE_NAME,
+      locale: "en_US",
+      images: [image],
+    },
+    twitter: {
+      card: twitterCard(image),
+      title,
+      description,
+      images: [image.url],
+    },
+  };
+}

--- a/app/side-projects/audiobolo/page.js
+++ b/app/side-projects/audiobolo/page.js
@@ -11,22 +11,17 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
+import { ogImages, pageMetadata } from "../../seo";
 
 const SITE = "https://audiobolo.com";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "AudioBolo - AI Voice to Text for macOS | Sarthak Shrivastava",
   description:
     "AudioBolo is an AI-powered voice transcription app for macOS that turns speech into accurate, context-aware text — type at the speed of thought.",
-  openGraph: {
-    title: "AudioBolo - AI Voice to Text for macOS | Sarthak Shrivastava",
-    description:
-      "AudioBolo is an AI-powered voice transcription app for macOS that turns speech into accurate, context-aware text — type at the speed of thought.",
-    url: "https://sarthaksavvy.com/side-projects/audiobolo",
-    siteName: "Sarthak Shrivastava - AudioBolo",
-    images: "/images/projects/audiobolo.png",
-  },
-};
+  path: "/side-projects/audiobolo",
+  image: ogImages.audiobolo,
+});
 
 export default function AudioBoloProject() {
   const features = [

--- a/app/side-projects/backstage-cut/page.js
+++ b/app/side-projects/backstage-cut/page.js
@@ -10,22 +10,17 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
+import { ogImages, pageMetadata } from "../../seo";
 
 const SITE = "https://premier-pro-extension.vercel.app";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "Backstage Cut - AI Premiere Pro Extension | Sarthak Shrivastava",
   description:
     "Backstage Cut is an AI-powered Premiere Pro extension that handles transcription, captions, zooms, B-roll and chapters without leaving the timeline.",
-  openGraph: {
-    title: "Backstage Cut - AI Premiere Pro Extension | Sarthak Shrivastava",
-    description:
-      "Backstage Cut is an AI-powered Premiere Pro extension that handles transcription, captions, zooms, B-roll and chapters without leaving the timeline.",
-    url: "https://sarthaksavvy.com/side-projects/backstage-cut",
-    siteName: "Sarthak Shrivastava - Backstage Cut",
-    images: "/images/projects/backstage-cut.png",
-  },
-};
+  path: "/side-projects/backstage-cut",
+  image: ogImages.backstageCut,
+});
 
 export default function BackstageCutProject() {
   const features = [

--- a/app/side-projects/expensorr/page.js
+++ b/app/side-projects/expensorr/page.js
@@ -9,20 +9,15 @@ import {
   Star,
 } from "lucide-react";
 import Link from "next/link";
+import { ogImages, pageMetadata } from "../../seo";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "Expensorr - Expense Tracking App | Sarthak Shrivastava",
   description:
     "Expensorr is a simple yet powerful expense tracking application that helps you monitor and manage your personal finances with ease.",
-  openGraph: {
-    title: "Expensorr - Expense Tracking App | Sarthak Shrivastava",
-    description:
-      "Expensorr is a simple yet powerful expense tracking application that helps you monitor and manage your personal finances with ease.",
-    url: "https://sarthaksavvy.com/side-projects/expensorr",
-    siteName: "Sarthak Shrivastava - Expensorr",
-    images: "/images/projects/expensorr.png",
-  },
-};
+  path: "/side-projects/expensorr",
+  image: ogImages.expensorr,
+});
 
 export default function ExpensorrProject() {
   const features = [
@@ -260,7 +255,9 @@ export default function ExpensorrProject() {
                     />
                   ))}
                 </div>
-                <p className="text-ink/70 mb-6">"{testimonial.text}"</p>
+                <p className="text-ink/70 mb-6">
+                  &quot;{testimonial.text}&quot;
+                </p>
                 <p className="font-semibold">{testimonial.author}</p>
               </div>
             ))}

--- a/app/side-projects/ginger/page.js
+++ b/app/side-projects/ginger/page.js
@@ -10,20 +10,15 @@ import {
   Zap,
 } from "lucide-react";
 import Link from "next/link";
+import { ogImages, pageMetadata } from "../../seo";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "Ginger - LinkedIn AI Assistant | Sarthak Shrivastava",
   description:
     "Ginger is a Chrome extension that helps users generate human-like comments using AI on LinkedIn posts and reply to existing comments effortlessly.",
-  openGraph: {
-    title: "Ginger - LinkedIn AI Assistant | Sarthak Shrivastava",
-    description:
-      "Ginger is a Chrome extension that helps users generate human-like comments using AI on LinkedIn posts and reply to existing comments effortlessly.",
-    url: "https://sarthaksavvy.com/side-projects/ginger",
-    siteName: "Sarthak Shrivastava - Ginger",
-    images: "/images/projects/ginger.jpg",
-  },
-};
+  path: "/side-projects/ginger",
+  image: ogImages.ginger,
+});
 
 export default function GingerProject() {
   const features = [
@@ -214,7 +209,8 @@ export default function GingerProject() {
                 </div>
                 <h3 className="text-xl font-bold mb-2">Browse</h3>
                 <p className="text-ink/70">
-                  Navigate to LinkedIn and find posts you'd like to engage with
+                  Navigate to LinkedIn and find posts you&apos;d like to engage
+                  with
                   in your feed or network.
                 </p>
               </div>
@@ -258,7 +254,7 @@ export default function GingerProject() {
                   ))}
                 </div>
                 <p className="text-ink/70 mb-6 italic">
-                  "{testimonial.text}"
+                  &quot;{testimonial.text}&quot;
                 </p>
                 <p className="font-medium">- {testimonial.author}</p>
               </div>

--- a/app/side-projects/mezohub/page.js
+++ b/app/side-projects/mezohub/page.js
@@ -10,20 +10,15 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import ClientImage from "../../components/ClientImage";
+import { ogImages, pageMetadata } from "../../seo";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "Mezohub - Backend Deployment Platform | Sarthak Shrivastava",
   description:
     "Mezohub is a platform for developers, freelancers, and entrepreneurs to deploy your backend project with ease.",
-  openGraph: {
-    title: "Mezohub - Backend Deployment Platform | Sarthak Shrivastava",
-    description:
-      "Mezohub is a platform for developers, freelancers, and entrepreneurs to deploy your backend project with ease.",
-    url: "https://sarthaksavvy.com/side-projects/mezohub",
-    siteName: "Sarthak Shrivastava - Mezohub",
-    images: "/images/projects/mezohub.jpg",
-  },
-};
+  path: "/side-projects/mezohub",
+  image: ogImages.mezohub,
+});
 
 export default function MezohubProject() {
   const features = [

--- a/app/side-projects/page.js
+++ b/app/side-projects/page.js
@@ -5,21 +5,13 @@ import Reveal from "../components/motion/Reveal";
 import { StaggerGroup, StaggerItem } from "../components/motion/Stagger";
 import MagneticButton from "../components/motion/MagneticButton";
 import TiltCard from "../components/motion/TiltCard";
+import { pageMetadata } from "../seo";
 
-export const metadata = {
+export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Side Projects",
   description: "Side Projects by Sarthak Shrivastava",
-  alternates: {
-    canonical: "https://sarthaksavvy.com/side-projects",
-  },
-  openGraph: {
-    title: "Sarthak Shrivastava - Side Projects",
-    description: "Side Projects by Sarthak Shrivastava",
-    url: "https://sarthaksavvy.com/side-projects",
-    siteName: "Sarthak Shrivastava - Side Projects",
-    images: "/sarthak.jpg",
-  },
-};
+  path: "/side-projects",
+});
 
 export default function SideProjects() {
   const projects = [


### PR DESCRIPTION
## What changed

**The bug:** every OpenGraph image on the site pointed at a path that does not exist. The metadata referenced `/sarthak.jpg` and `/laravel-india-podcast.png`, but those files live under `/public/images/`. Social crawlers 404'd on all of them, so the home, side-projects, public-speaking and podcasts pages shared as a bare link with no preview image.

The metadata was also hand-copied into each route, which is how the paths drifted apart in the first place. `app/seo.js` now builds the canonical, OpenGraph and Twitter tags from one place, so a wrong image path is a one-line fix rather than an eight-file one.

Alongside that:

- **Twitter cards.** The site had none — X does not read OpenGraph tags, so shares there rendered no card at all. Images under 600px wide get the compact `summary` card instead of a stretched banner.
- **Image dimensions and alt text** are now declared, so crawlers can lay a card out before the file finishes downloading.
- **Canonical URLs** added to the five project pages, which were missing them.
- **Sitemap gap fixed:** `/side-projects/backstage-cut` and `/side-projects/audiobolo` shipped after the sitemap landed and were never registered in `routes.js`, so neither page was in `sitemap.xml`. Both are now included.
- **Root layout defaults** for OpenGraph and Twitter, so a route that forgets its own metadata still shares with a working card. Deliberately no canonical at that level — it would be inherited by every page that does not declare one and point them all at `/`. Verified: `/ask` still renders `noindex, follow` with no canonical.

No page titles or descriptions were changed. The existing copy is reused verbatim; only paths, tag coverage and the canonical/sitemap plumbing moved.

## Why it helps

Broken OG images are a silent tax on every link ever shared to LinkedIn, X, Slack or WhatsApp — the post renders as an unadorned URL, which measurably suppresses click-through. Canonical tags on the project pages consolidate ranking signals rather than splitting them across query-string and trailing-slash variants, and the two unregistered project pages can now actually be discovered through the sitemap instead of relying on crawlers finding them by internal link alone.

## Files touched

- `app/seo.js` — new: image registry plus `pageMetadata()` / `canonicalUrl()` helpers
- `app/routes.js` — registered the two missing project routes
- `app/layout.js` — site-wide OG/Twitter defaults
- `app/page.js`, `app/about-me/page.js`, `app/podcasts/page.js`, `app/public-speaking/page.js`, `app/side-projects/page.js` — switched to the helper
- `app/side-projects/{audiobolo,backstage-cut,expensorr,ginger,mezohub}/page.js` — switched to the helper, gained canonicals
- `app/components/EntryGate.js`, `app/components/Footer.js` — lint fix only

No dependencies added.

## Build and lint status

- `npm run lint` — **clean**, zero errors (only the pre-existing `no-img-element` warnings remain). This PR also clears the ESLint *errors* that were already red on `main`: unescaped quotes in the Expensorr and Ginger pages, and the `//` display strings in About Me, EntryGate and Footer that ESLint read as stray comments. All of those render identically to before.
- `npm run build` — **passes**, 18/18 static pages generated. Rendered tags were checked in the build output: absolute image URLs, correct canonicals, and the two new sitemap entries all confirmed.

## Pre-existing issues found but not fixed here

1. **`npm run build` fails on `main` without `OPENROUTER_API_KEY` set.** `app/api/ask/route.js` constructs the OpenAI client at module scope, and Next's page-data collection imports that module, so the production build aborts in any environment where the key is absent. This reproduces on `main` and is unrelated to this PR — I verified this branch's build with a dummy key. The fix is to instantiate the client lazily inside the handler; it touches an API route and env-var handling, so I have left it for a separate, reviewed change rather than folding it in here.
2. **The podcast cover is 3000×3000 and 7 MB.** The path is now correct, but that file exceeds X's 5 MB card limit and will likely still be dropped there. A 1200×630 export under ~1 MB would fix it; no image tooling was available in this environment to generate one, and I did not want to invent an asset.

No TODO placeholders were left in the code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcJauCYJe6ACLXqsW6etbK)_