### PR TITLE
Add schema.org structured data across the site, and fix the build without an API key

### DIFF
--- a/app/about-me/page.js
+++ b/app/about-me/page.js
@@ -2,13 +2,28 @@ import Image from "next/image";
 import Reveal from "../components/motion/Reveal";
 import { StaggerGroup, StaggerItem } from "../components/motion/Stagger";
 import MagneticButton from "../components/motion/MagneticButton";
-import { pageMetadata } from "../seo";
+import JsonLd from "../components/JsonLd";
+import { canonicalUrl, pageMetadata } from "../seo";
+import { breadcrumbSchema, graph, personSchema } from "../structuredData";
 
 export const metadata = pageMetadata({
   title: "About Me - Sarthaksavvy",
   description: "Get to know Sarthak Shrivastava's journey in tech.",
   path: "/about-me",
 });
+
+// The page a crawler should treat as the profile of the person, which is what
+// makes the roles, credentials and social links here attributable rather than
+// loose text on a page.
+const structuredData = graph(
+  {
+    "@type": "ProfilePage",
+    url: canonicalUrl("/about-me"),
+    name: "About Sarthak Shrivastava",
+    mainEntity: personSchema(),
+  },
+  breadcrumbSchema([{ name: "About Me", path: "/about-me" }])
+);
 
 const currentRoles = [
   "Founder of Bitfumes",
@@ -55,6 +70,7 @@ function ListCard({ title, items }) {
 const AboutPage = () => {
   return (
     <div className="py-10 px-6 sm:px-10">
+      <JsonLd data={structuredData} />
       <div className="max-w-[1400px] mx-auto">
         <div className="mb-20 grid md:grid-cols-12 gap-6">
           <Reveal className="md:col-span-8">

--- a/app/api/ask/route.js
+++ b/app/api/ask/route.js
@@ -21,14 +21,22 @@ function maxTokensFor(question) {
     : MAX_TOKENS_DEFAULT;
 }
 
-const openrouter = new OpenAI({
-  apiKey: process.env.OPENROUTER_API_KEY,
-  baseURL: "https://openrouter.ai/api/v1",
-  defaultHeaders: {
-    "HTTP-Referer": SITE_URL,
-    "X-Title": "Ask About Sarthak",
-  },
-});
+// Built per request rather than once at module scope. The SDK constructor
+// throws when it cannot find a key, and at build time there is no key to find
+// — which made `next build` fail while collecting this route unless the
+// environment happened to carry OPENROUTER_API_KEY. It also meant the missing
+// key check further down could never run, because the module blew up before
+// the handler was ever reached.
+function openrouterClient() {
+  return new OpenAI({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseURL: "https://openrouter.ai/api/v1",
+    defaultHeaders: {
+      "HTTP-Referer": SITE_URL,
+      "X-Title": "Ask About Sarthak",
+    },
+  });
+}
 
 const CACHE_TTL = 1000 * 60 * 60; // 1 hour
 let contentCache = {
@@ -253,7 +261,7 @@ Instructions:
 - Maintain a professional yet friendly tone
 - If asked about contact information, direct them to his website or LinkedIn`;
 
-    const completion = await openrouter.chat.completions.create({
+    const completion = await openrouterClient().chat.completions.create({
       model: MODEL,
       max_tokens: maxTokensFor(sanitizedQuestion),
       temperature: 0.7,

--- a/app/components/JsonLd.js
+++ b/app/components/JsonLd.js
@@ -1,0 +1,19 @@
+// Renders a schema.org block for crawlers. Nothing here is visible to a
+// visitor — it is the machine-readable copy of what the page already says.
+//
+// The `</` escape matters: a JSON string containing "</script>" would close
+// this tag early and turn the rest of the payload into markup. All the data on
+// the site is static, but the escape keeps that true if a value ever starts
+// coming from somewhere else.
+function serialize(data) {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+export default function JsonLd({ data }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serialize(data) }}
+    />
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,8 @@
 import Hero from "./components/Hero";
 import Marquee from "./components/Marquee";
+import JsonLd from "./components/JsonLd";
 import { pageMetadata } from "./seo";
+import { graph, personSchema, websiteSchema } from "./structuredData";
 
 export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Sarthaksavvy",
@@ -11,6 +13,7 @@ export const metadata = pageMetadata({
 export default function Home() {
   return (
     <>
+      <JsonLd data={graph(personSchema(), websiteSchema())} />
       <Hero />
       <Marquee />
     </>

--- a/app/podcasts/page.js
+++ b/app/podcasts/page.js
@@ -3,7 +3,9 @@ import Image from "next/image";
 import Reveal from "../components/motion/Reveal";
 import MagneticButton from "../components/motion/MagneticButton";
 import TiltCard from "../components/motion/TiltCard";
-import { ogImages, pageMetadata } from "../seo";
+import JsonLd from "../components/JsonLd";
+import { canonicalUrl, ogImages, pageMetadata } from "../seo";
+import { breadcrumbSchema, graph, personSchema } from "../structuredData";
 
 export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Podcasts",
@@ -27,9 +29,29 @@ const platforms = [
   },
 ];
 
+// `sameAs` is what ties this page to the show as Apple, Spotify and YouTube
+// already know it, so the three listings and this page are understood as one
+// podcast rather than four unrelated URLs.
+const structuredData = graph(
+  {
+    "@type": "PodcastSeries",
+    name: "Laravel India Podcast",
+    url: canonicalUrl("/podcasts"),
+    description:
+      "Conversations with guests from the worldwide Laravel community, " +
+      "including Taylor Otwell, James Brooks and Freek Van der Herten.",
+    image: canonicalUrl(ogImages.podcast.url),
+    inLanguage: "en",
+    author: personSchema(),
+    sameAs: platforms.map((platform) => platform.href),
+  },
+  breadcrumbSchema([{ name: "Podcasts", path: "/podcasts" }])
+);
+
 export default function Podcasts() {
   return (
     <div className="py-10 px-6 sm:px-10">
+      <JsonLd data={structuredData} />
       <div className="max-w-[1400px] mx-auto">
         <div className="mb-20 grid md:grid-cols-12 gap-6">
           <Reveal className="md:col-span-8">

--- a/app/public-speaking/page.js
+++ b/app/public-speaking/page.js
@@ -3,7 +3,13 @@ import SingleEvent from "../components/PublicSpeaking/SingleEvent";
 import speakingEvents from "../events.json";
 import Reveal from "../components/motion/Reveal";
 import MagneticButton from "../components/motion/MagneticButton";
+import JsonLd from "../components/JsonLd";
 import { pageMetadata } from "../seo";
+import {
+  breadcrumbSchema,
+  graph,
+  speakingEventsSchema,
+} from "../structuredData";
 
 export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Public Speaking",
@@ -11,9 +17,15 @@ export const metadata = pageMetadata({
   path: "/public-speaking",
 });
 
+const structuredData = graph(
+  speakingEventsSchema(speakingEvents),
+  breadcrumbSchema([{ name: "Public Speaking", path: "/public-speaking" }])
+);
+
 export default function SpeakingTimeline() {
   return (
     <div className="py-10 px-6 sm:px-10">
+      <JsonLd data={structuredData} />
       <div className="max-w-[1400px] mx-auto">
         <div className="mb-20 grid md:grid-cols-12 gap-6">
           <Reveal className="md:col-span-8">

--- a/app/side-projects/audiobolo/page.js
+++ b/app/side-projects/audiobolo/page.js
@@ -11,17 +11,41 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
+import JsonLd from "../../components/JsonLd";
 import { ogImages, pageMetadata } from "../../seo";
+import {
+  breadcrumbSchema,
+  graph,
+  softwareApplicationSchema,
+} from "../../structuredData";
 
 const SITE = "https://audiobolo.com";
 
+const DESCRIPTION =
+  "AudioBolo is an AI-powered voice transcription app for macOS that turns speech into accurate, context-aware text — type at the speed of thought.";
+
 export const metadata = pageMetadata({
   title: "AudioBolo - AI Voice to Text for macOS | Sarthak Shrivastava",
-  description:
-    "AudioBolo is an AI-powered voice transcription app for macOS that turns speech into accurate, context-aware text — type at the speed of thought.",
+  description: DESCRIPTION,
   path: "/side-projects/audiobolo",
   image: ogImages.audiobolo,
 });
+
+const structuredData = graph(
+  softwareApplicationSchema({
+    name: "AudioBolo",
+    description: DESCRIPTION,
+    url: SITE,
+    path: "/side-projects/audiobolo",
+    image: ogImages.audiobolo.url,
+    applicationCategory: "UtilitiesApplication",
+    operatingSystem: "macOS",
+  }),
+  breadcrumbSchema([
+    { name: "Side Projects", path: "/side-projects" },
+    { name: "AudioBolo", path: "/side-projects/audiobolo" },
+  ])
+);
 
 export default function AudioBoloProject() {
   const features = [
@@ -113,6 +137,7 @@ export default function AudioBoloProject() {
 
   return (
     <div className="min-h-screen bg-paper text-ink py-16 px-6">
+      <JsonLd data={structuredData} />
       <div className="container mx-auto max-w-6xl">
         {/* Back Navigation */}
         <div className="mb-12">

--- a/app/side-projects/backstage-cut/page.js
+++ b/app/side-projects/backstage-cut/page.js
@@ -10,17 +10,40 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
+import JsonLd from "../../components/JsonLd";
 import { ogImages, pageMetadata } from "../../seo";
+import {
+  breadcrumbSchema,
+  graph,
+  softwareApplicationSchema,
+} from "../../structuredData";
 
 const SITE = "https://premier-pro-extension.vercel.app";
 
+const DESCRIPTION =
+  "Backstage Cut is an AI-powered Premiere Pro extension that handles transcription, captions, zooms, B-roll and chapters without leaving the timeline.";
+
 export const metadata = pageMetadata({
   title: "Backstage Cut - AI Premiere Pro Extension | Sarthak Shrivastava",
-  description:
-    "Backstage Cut is an AI-powered Premiere Pro extension that handles transcription, captions, zooms, B-roll and chapters without leaving the timeline.",
+  description: DESCRIPTION,
   path: "/side-projects/backstage-cut",
   image: ogImages.backstageCut,
 });
+
+const structuredData = graph(
+  softwareApplicationSchema({
+    name: "Backstage Cut",
+    description: DESCRIPTION,
+    url: SITE,
+    path: "/side-projects/backstage-cut",
+    image: ogImages.backstageCut.url,
+    applicationCategory: "MultimediaApplication",
+  }),
+  breadcrumbSchema([
+    { name: "Side Projects", path: "/side-projects" },
+    { name: "Backstage Cut", path: "/side-projects/backstage-cut" },
+  ])
+);
 
 export default function BackstageCutProject() {
   const features = [
@@ -97,6 +120,7 @@ export default function BackstageCutProject() {
 
   return (
     <div className="min-h-screen bg-paper text-ink py-16 px-6">
+      <JsonLd data={structuredData} />
       <div className="container mx-auto max-w-6xl">
         {/* Back Navigation */}
         <div className="mb-12">

--- a/app/side-projects/expensorr/page.js
+++ b/app/side-projects/expensorr/page.js
@@ -9,15 +9,41 @@ import {
   Star,
 } from "lucide-react";
 import Link from "next/link";
+import JsonLd from "../../components/JsonLd";
 import { ogImages, pageMetadata } from "../../seo";
+import {
+  breadcrumbSchema,
+  graph,
+  softwareApplicationSchema,
+} from "../../structuredData";
+
+const SITE = "https://apps.apple.com/us/app/expensorr/id6739472004";
+
+const DESCRIPTION =
+  "Expensorr is a simple yet powerful expense tracking application that helps you monitor and manage your personal finances with ease.";
 
 export const metadata = pageMetadata({
   title: "Expensorr - Expense Tracking App | Sarthak Shrivastava",
-  description:
-    "Expensorr is a simple yet powerful expense tracking application that helps you monitor and manage your personal finances with ease.",
+  description: DESCRIPTION,
   path: "/side-projects/expensorr",
   image: ogImages.expensorr,
 });
+
+const structuredData = graph(
+  softwareApplicationSchema({
+    name: "Expensorr",
+    description: DESCRIPTION,
+    url: SITE,
+    path: "/side-projects/expensorr",
+    image: ogImages.expensorr.url,
+    applicationCategory: "FinanceApplication",
+    operatingSystem: "iOS",
+  }),
+  breadcrumbSchema([
+    { name: "Side Projects", path: "/side-projects" },
+    { name: "Expensorr", path: "/side-projects/expensorr" },
+  ])
+);
 
 export default function ExpensorrProject() {
   const features = [
@@ -67,6 +93,7 @@ export default function ExpensorrProject() {
 
   return (
     <div className="min-h-screen bg-paper text-ink py-16 px-6">
+      <JsonLd data={structuredData} />
       <div className="container mx-auto max-w-6xl">
         {/* Back Navigation */}
         <div className="mb-12">

--- a/app/side-projects/ginger/page.js
+++ b/app/side-projects/ginger/page.js
@@ -10,15 +10,42 @@ import {
   Zap,
 } from "lucide-react";
 import Link from "next/link";
+import JsonLd from "../../components/JsonLd";
 import { ogImages, pageMetadata } from "../../seo";
+import {
+  breadcrumbSchema,
+  graph,
+  softwareApplicationSchema,
+} from "../../structuredData";
+
+const SITE =
+  "https://chromewebstore.google.com/detail/ginger-linkedin-ai-assist/ijolijeckddogpijopofibpplokamjba";
+
+const DESCRIPTION =
+  "Ginger is a Chrome extension that helps users generate human-like comments using AI on LinkedIn posts and reply to existing comments effortlessly.";
 
 export const metadata = pageMetadata({
   title: "Ginger - LinkedIn AI Assistant | Sarthak Shrivastava",
-  description:
-    "Ginger is a Chrome extension that helps users generate human-like comments using AI on LinkedIn posts and reply to existing comments effortlessly.",
+  description: DESCRIPTION,
   path: "/side-projects/ginger",
   image: ogImages.ginger,
 });
+
+const structuredData = graph(
+  softwareApplicationSchema({
+    name: "Ginger",
+    description: DESCRIPTION,
+    url: SITE,
+    path: "/side-projects/ginger",
+    image: ogImages.ginger.url,
+    applicationCategory: "BrowserApplication",
+    operatingSystem: "Chrome",
+  }),
+  breadcrumbSchema([
+    { name: "Side Projects", path: "/side-projects" },
+    { name: "Ginger", path: "/side-projects/ginger" },
+  ])
+);
 
 export default function GingerProject() {
   const features = [
@@ -68,6 +95,7 @@ export default function GingerProject() {
 
   return (
     <div className="min-h-screen bg-paper text-ink py-16 px-6">
+      <JsonLd data={structuredData} />
       <div className="container mx-auto max-w-6xl">
         {/* Back Navigation */}
         <div className="mb-12">

--- a/app/side-projects/mezohub/page.js
+++ b/app/side-projects/mezohub/page.js
@@ -10,15 +10,41 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import ClientImage from "../../components/ClientImage";
+import JsonLd from "../../components/JsonLd";
 import { ogImages, pageMetadata } from "../../seo";
+import {
+  breadcrumbSchema,
+  graph,
+  softwareApplicationSchema,
+} from "../../structuredData";
+
+const SITE = "https://mezohub.com";
+
+const DESCRIPTION =
+  "Mezohub is a platform for developers, freelancers, and entrepreneurs to deploy your backend project with ease.";
 
 export const metadata = pageMetadata({
   title: "Mezohub - Backend Deployment Platform | Sarthak Shrivastava",
-  description:
-    "Mezohub is a platform for developers, freelancers, and entrepreneurs to deploy your backend project with ease.",
+  description: DESCRIPTION,
   path: "/side-projects/mezohub",
   image: ogImages.mezohub,
 });
+
+const structuredData = graph(
+  softwareApplicationSchema({
+    name: "Mezohub",
+    description: DESCRIPTION,
+    url: SITE,
+    path: "/side-projects/mezohub",
+    image: ogImages.mezohub.url,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Web",
+  }),
+  breadcrumbSchema([
+    { name: "Side Projects", path: "/side-projects" },
+    { name: "Mezohub", path: "/side-projects/mezohub" },
+  ])
+);
 
 export default function MezohubProject() {
   const features = [
@@ -80,6 +106,7 @@ export default function MezohubProject() {
 
   return (
     <div className="min-h-screen bg-paper text-ink py-16 px-6">
+      <JsonLd data={structuredData} />
       <div className="container mx-auto max-w-6xl">
         {/* Back Navigation */}
         <div className="mb-12">

--- a/app/side-projects/page.js
+++ b/app/side-projects/page.js
@@ -5,7 +5,9 @@ import Reveal from "../components/motion/Reveal";
 import { StaggerGroup, StaggerItem } from "../components/motion/Stagger";
 import MagneticButton from "../components/motion/MagneticButton";
 import TiltCard from "../components/motion/TiltCard";
-import { pageMetadata } from "../seo";
+import JsonLd from "../components/JsonLd";
+import { canonicalUrl, pageMetadata } from "../seo";
+import { breadcrumbSchema, graph } from "../structuredData";
 
 export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Side Projects",
@@ -97,8 +99,26 @@ export default function SideProjects() {
     },
   ];
 
+  // Listing the projects as an ordered set of pages gives the index a reason
+  // to be crawled past its own copy: each entry names a detail page a crawler
+  // might otherwise only reach by following a card link.
+  const structuredData = graph(
+    {
+      "@type": "ItemList",
+      name: "Side projects by Sarthak Shrivastava",
+      itemListElement: projects.map((project, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: project.name,
+        url: canonicalUrl(project.projectLink),
+      })),
+    },
+    breadcrumbSchema([{ name: "Side Projects", path: "/side-projects" }])
+  );
+
   return (
     <div className="py-10 px-6 sm:px-10">
+      <JsonLd data={structuredData} />
       <div className="max-w-[1400px] mx-auto">
         <div className="mb-20 grid md:grid-cols-12 gap-6">
           <Reveal className="md:col-span-8">

--- a/app/structuredData.js
+++ b/app/structuredData.js
@@ -1,0 +1,231 @@
+import { SITE_URL } from "./routes";
+import { SITE_NAME, canonicalUrl } from "./seo";
+
+// Schema.org descriptions of the site. Search engines read the pages fine on
+// their own; what they cannot infer is the *shape* of the thing they are
+// reading — that "Sarthak Shrivastava" is a person who consults on AI rather
+// than a company, that the podcast page is a show with episodes on Spotify,
+// that a project page describes an application. Saying so explicitly is what
+// makes a knowledge panel, a podcast result or a sitelink possible.
+//
+// Every fact below is already stated somewhere the visitor can read it. If a
+// claim is not on the site, it does not belong here either.
+
+const PERSON_ID = `${SITE_URL}/#person`;
+const WEBSITE_ID = `${SITE_URL}/#website`;
+
+const socialProfiles = [
+  "https://linkedin.com/in/sarthaksavvy",
+  "https://github.com/sarthaksavvy",
+  "https://x.com/sarthaksavvy",
+  "https://instagram.com/sarthaksavvy",
+  "https://youtube.com/bitfumes",
+];
+
+/**
+ * The Person every other schema on the site points back at. Cross-page `@id`
+ * references are not resolved by crawlers, so this is emitted in full wherever
+ * it is needed rather than linked to.
+ */
+export function personSchema() {
+  return {
+    "@type": "Person",
+    "@id": PERSON_ID,
+    name: SITE_NAME,
+    alternateName: "sarthaksavvy",
+    jobTitle: ["AI Consultant", "Founder", "Software Engineer"],
+    description:
+      "India-based founder, content creator, developer and AI consultant — " +
+      "passionate about building products and automating daily work.",
+    url: SITE_URL,
+    image: canonicalUrl("/images/sarthak.jpg"),
+    email: "mailto:hello@sarthaksavvy.com",
+    address: {
+      "@type": "PostalAddress",
+      addressCountry: "IN",
+    },
+    worksFor: [
+      {
+        "@type": "Organization",
+        name: "Bitfumes",
+        url: "https://bitfumes.com",
+      },
+      {
+        "@type": "Organization",
+        name: "Pfizer",
+      },
+    ],
+    knowsAbout: [
+      "Artificial Intelligence",
+      "Large Language Models",
+      "AI Automation",
+      "Laravel",
+      "JavaScript",
+      "Python",
+      "AWS",
+      "Docker",
+      "DevOps",
+      "Full-stack Development",
+    ],
+    award: "Docker Captain",
+    hasCredential: [
+      {
+        "@type": "EducationalOccupationalCredential",
+        name: "AWS Certified Solutions Architect",
+      },
+      {
+        "@type": "EducationalOccupationalCredential",
+        name: "AWS Certified Developer",
+      },
+    ],
+    sameAs: socialProfiles,
+  };
+}
+
+export function websiteSchema() {
+  return {
+    "@type": "WebSite",
+    "@id": WEBSITE_ID,
+    name: SITE_NAME,
+    url: SITE_URL,
+    inLanguage: "en",
+    publisher: { "@id": PERSON_ID },
+  };
+}
+
+/**
+ * Wraps one or more nodes in the `@graph` envelope so a page emits a single
+ * script tag instead of one per node.
+ */
+export function graph(...nodes) {
+  return {
+    "@context": "https://schema.org",
+    "@graph": nodes.flat(),
+  };
+}
+
+/**
+ * Breadcrumbs let a result show "sarthaksavvy.com › Side Projects › AudioBolo"
+ * instead of a bare URL. `trail` is ordered from the root down; the home crumb
+ * is added here so no caller has to remember it.
+ */
+export function breadcrumbSchema(trail) {
+  const crumbs = [{ name: "Home", path: "/" }, ...trail];
+
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: crumbs.map(({ name, path }, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name,
+      item: canonicalUrl(path),
+    })),
+  };
+}
+
+const MONTHS = [
+  "january",
+  "february",
+  "march",
+  "april",
+  "may",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+];
+
+/**
+ * "September 24, 2024" -> "2024-09-24". Schema.org wants ISO 8601 and the
+ * events file stores the human form, so the two are reconciled here rather
+ * than by duplicating every date in the data. Returns null on anything this
+ * does not recognise, which drops the event from the markup instead of
+ * publishing a date a crawler will reject.
+ */
+export function isoDate(humanDate) {
+  const match = /^([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})$/.exec(
+    String(humanDate).trim()
+  );
+  if (!match) return null;
+
+  const month = MONTHS.indexOf(match[1].toLowerCase());
+  if (month === -1) return null;
+
+  return `${match[3]}-${String(month + 1).padStart(2, "0")}-${match[2].padStart(
+    2,
+    "0"
+  )}`;
+}
+
+/**
+ * The talks on the speaking page, described as events with a performer, so a
+ * conference listing and this page can be recognised as the same appearance.
+ */
+export function speakingEventsSchema(events) {
+  const person = personSchema();
+
+  const items = events
+    .map((event) => {
+      const startDate = isoDate(event.date);
+      if (!startDate) return null;
+
+      return {
+        "@type": "Event",
+        name: event.title.trim(),
+        description: event.description,
+        startDate,
+        eventStatus: "https://schema.org/EventScheduled",
+        eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+        location: {
+          "@type": "Place",
+          name: event.conference,
+          address: event.location,
+        },
+        ...(event.images?.length
+          ? { image: canonicalUrl(event.images[0]) }
+          : {}),
+        performer: person,
+      };
+    })
+    .filter(Boolean);
+
+  return {
+    "@type": "ItemList",
+    name: "Talks by Sarthak Shrivastava",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item,
+    })),
+  };
+}
+
+/**
+ * A project page describes a piece of software, not an article about one.
+ * `url` is the product's own site — the page itself is already the canonical
+ * `mainEntityOfPage`.
+ */
+export function softwareApplicationSchema({
+  name,
+  description,
+  url,
+  path,
+  image,
+  applicationCategory,
+  operatingSystem,
+}) {
+  return {
+    "@type": "SoftwareApplication",
+    name,
+    description,
+    url,
+    image: canonicalUrl(image),
+    applicationCategory,
+    ...(operatingSystem ? { operatingSystem } : {}),
+    mainEntityOfPage: canonicalUrl(path),
+    author: personSchema(),
+  };
+}


### PR DESCRIPTION
## What changed

The site had no JSON-LD anywhere. Metadata, canonicals, sitemap and robots landed in #4 and #5 — this is the remaining half: telling crawlers *what kind of thing* each page describes, rather than leaving them to infer it from prose.

Two new files do the work, and each page opts in:

- `app/structuredData.js` — the schema builders and the one definition of the `Person`.
- `app/components/JsonLd.js` — renders the `<script type="application/ld+json">` block, escaping `<` so a value can never close the tag early.

Per page:

| Page | Schema |
| --- | --- |
| `/` | `Person` + `WebSite` |
| `/about-me` | `ProfilePage` wrapping the `Person` |
| `/podcasts` | `PodcastSeries`, with Apple / Spotify / YouTube as `sameAs` |
| `/public-speaking` | `ItemList` of the six talks as `Event`s |
| `/side-projects` | `ItemList` linking each detail page |
| 5 project pages | `SoftwareApplication` |
| everything below root | `BreadcrumbList` |

## Why it helps

- **`Person` with `jobTitle: AI Consultant`, `knowsAbout` and `sameAs`** is the entity signal behind a knowledge panel. Without it, "Sarthak Shrivastava" and the LinkedIn / GitHub / X / YouTube profiles are five unconnected URLs; `sameAs` is what merges them into one entity, and `knowsAbout` is what associates that entity with AI, LLMs and automation rather than only with Laravel.
- **`PodcastSeries` + `sameAs`** ties this page to the show as Apple and Spotify already know it, so four listings are understood as one podcast.
- **`Event`** makes each talk eligible for event treatment. The dates in `events.json` are human-readable ("September 24, 2024"), so they are converted to ISO 8601; anything unparseable is dropped from the markup rather than published as a date a crawler will reject.
- **`BreadcrumbList`** replaces the bare URL in a result with `sarthaksavvy.com › Side Projects › AudioBolo`.
- **`SoftwareApplication`** marks a project page as describing an app, with its category and platform.

Every URL is built through the existing `canonicalUrl()` helper, so the markup, the canonical tags and the sitemap cannot drift apart.

## Bug fix included

`npm run build` failed on `main` whenever `OPENROUTER_API_KEY` was not in the build environment:

```
Error: The OPENAI_API_KEY environment variable is missing or empty
Error: Failed to collect page data for /api/ask
```

`/api/ask` constructed its OpenAI client at module scope, and the SDK constructor throws when it cannot find a key — so the module could not even load during page-data collection. As a side effect, the route's own "API key not configured" check was unreachable code. The client is now built per request; that check can now actually run. No change to behaviour when the key is present.

I had to fix this to verify anything, so it rides along here.

## Files touched

- new: `app/structuredData.js`, `app/components/JsonLd.js`
- wired up: `app/page.js`, `app/about-me/page.js`, `app/podcasts/page.js`, `app/public-speaking/page.js`, `app/side-projects/page.js` and the five project pages
- bug fix: `app/api/ask/route.js`

On the project pages the metadata description was lifted into a `DESCRIPTION` const so the schema and the `<meta>` tag cannot disagree. Same strings, no rewording.

## Build / lint

- `npm ci` → clean
- `npm run build` → passes, 18/18 static pages
- `npm run lint` → only the four pre-existing `no-img-element` warnings in `ParticleImage.js` and `expensorr/page.js`; nothing new
- Parsed the JSON-LD back out of all ten built HTML files: valid JSON, correct `@type`s, all six event dates converted correctly, canonical URLs matching the sitemap

## No TODO placeholders

No invented facts. Every value — job titles, Docker Captain, the AWS certifications, the social links, the talk dates and locations, the project descriptions — is copied from what the site already says. No ratings, prices or review counts, since there are none to state truthfully.

## NEEDS APPROVAL

Two reasons, either one sufficient:

1. **Personal information and positioning.** The `Person` block publishes, in machine-readable form, Sarthak's job titles (including `AI Consultant`), employers (Bitfumes and Pfizer), credentials, public email and social profiles. Nothing here is new to the site, but it is a statement about Sarthak aimed at search engines and worth a read-through before it ships.
2. **Environment variables.** The `/api/ask` fix changes when `OPENROUTER_API_KEY` is read — per request instead of at module load.

No visible copy changed, and no dependencies were added. Not merging; leaving this open for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwMnbnwtC6GTDVzNroiGwa)_