### PR TITLE
Fix duplicate h1 on every page and make the intro overlay a real dialog

### DIFF
--- a/app/components/EntryGate.js
+++ b/app/components/EntryGate.js
@@ -1,7 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+
+const FOCUSABLE =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 function playSound(src, onEnded) {
   try {
@@ -19,8 +22,10 @@ export default function EntryGate() {
   const [visible, setVisible] = useState(false);
   const [ready, setReady] = useState(false);
   const pendingRef = useRef({ audio: null, onFirstMove: null });
+  const panelRef = useRef(null);
+  const lastFocusedRef = useRef(null);
 
-  function cancelPendingSequence() {
+  const cancelPendingSequence = useCallback(() => {
     const pending = pendingRef.current;
     if (pending.onFirstMove) {
       window.removeEventListener("mousemove", pending.onFirstMove);
@@ -29,7 +34,7 @@ export default function EntryGate() {
       pending.audio.pause();
     }
     pendingRef.current = { audio: null, onFirstMove: null };
-  }
+  }, []);
 
   useEffect(() => {
     const seen = sessionStorage.getItem("gate-seen");
@@ -48,26 +53,97 @@ export default function EntryGate() {
       window.removeEventListener("gate:reset", onReset);
       cancelPendingSequence();
     };
-  }, []);
+  }, [cancelPendingSequence]);
 
-  function enter(withSound) {
-    cancelPendingSequence();
-    sessionStorage.setItem("gate-seen", "1");
-    setVisible(false);
+  const enter = useCallback(
+    (withSound) => {
+      cancelPendingSequence();
+      sessionStorage.setItem("gate-seen", "1");
+      setVisible(false);
 
-    if (withSound) {
-      const authAudio = playSound("/sounds/user_authentication.mp3", () => {
-        function onFirstMove() {
-          window.removeEventListener("mousemove", onFirstMove);
-          pendingRef.current = { audio: null, onFirstMove: null };
-          pendingRef.current.audio = playSound("/sounds/inbound_signal_detected.mp3");
-        }
-        pendingRef.current = { audio: null, onFirstMove };
-        window.addEventListener("mousemove", onFirstMove);
-      });
-      pendingRef.current.audio = authAudio;
+      if (withSound) {
+        const authAudio = playSound("/sounds/user_authentication.mp3", () => {
+          function onFirstMove() {
+            window.removeEventListener("mousemove", onFirstMove);
+            pendingRef.current = { audio: null, onFirstMove: null };
+            pendingRef.current.audio = playSound(
+              "/sounds/inbound_signal_detected.mp3"
+            );
+          }
+          pendingRef.current = { audio: null, onFirstMove };
+          window.addEventListener("mousemove", onFirstMove);
+        });
+        pendingRef.current.audio = authAudio;
+      }
+    },
+    [cancelPendingSequence]
+  );
+
+  // The gate covers the entire page, so while it is open it has to behave like
+  // a modal dialog rather than a decorative overlay: focus moves into it, Tab
+  // stays inside it, Escape leaves, and the page behind it stops scrolling.
+  // Without that, a keyboard visitor tabs straight into a header they cannot
+  // see and a screen reader reads a page that is hidden behind an opaque
+  // panel.
+  useEffect(() => {
+    if (!visible) return;
+
+    lastFocusedRef.current = document.activeElement;
+
+    const panel = panelRef.current;
+    const focusables = () =>
+      Array.from(panel ? panel.querySelectorAll(FOCUSABLE) : []);
+
+    focusables()[0]?.focus();
+
+    function onKeyDown(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        enter(false);
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const items = focusables();
+      if (!items.length || !panel) return;
+
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      const outside = !panel.contains(active);
+
+      if (event.shiftKey && (outside || active === first)) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (outside || active === last)) {
+        event.preventDefault();
+        first.focus();
+      }
     }
-  }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [visible, enter]);
+
+  // Hand focus back to whatever the visitor was on before the gate opened, so
+  // "Replay Intro" returns them to that button instead of dropping them at the
+  // top of the document.
+  useEffect(() => {
+    if (visible) return;
+
+    const last = lastFocusedRef.current;
+    lastFocusedRef.current = null;
+    if (last && last !== document.body && document.contains(last)) {
+      last.focus();
+    }
+  }, [visible]);
 
   if (!ready) return null;
 
@@ -76,12 +152,18 @@ export default function EntryGate() {
       {visible && (
         <motion.div
           key="gate"
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="entry-gate-title"
+          aria-describedby="entry-gate-hint"
           className="fixed inset-0 z-[100] bg-paper text-ink flex items-center justify-center"
           initial={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.6, ease: "easeInOut" }}
         >
           <div
+            aria-hidden="true"
             className="absolute inset-0 opacity-[0.06]"
             style={{
               backgroundImage:
@@ -89,10 +171,22 @@ export default function EntryGate() {
               backgroundSize: "40px 40px",
             }}
           />
-          <div className="absolute top-6 left-6 w-6 h-6 border-l border-t border-ink/30" />
-          <div className="absolute top-6 right-6 w-6 h-6 border-r border-t border-ink/30" />
-          <div className="absolute bottom-6 left-6 w-6 h-6 border-l border-b border-ink/30" />
-          <div className="absolute bottom-6 right-6 w-6 h-6 border-r border-b border-ink/30" />
+          <div
+            aria-hidden="true"
+            className="absolute top-6 left-6 w-6 h-6 border-l border-t border-ink/30"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute top-6 right-6 w-6 h-6 border-r border-t border-ink/30"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute bottom-6 left-6 w-6 h-6 border-l border-b border-ink/30"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute bottom-6 right-6 w-6 h-6 border-r border-b border-ink/30"
+          />
 
           <motion.div
             className="relative text-center px-6"
@@ -100,15 +194,31 @@ export default function EntryGate() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.1 }}
           >
-            <p className="font-mono text-xs tracking-[0.3em] text-muted mb-4">
+            <p
+              aria-hidden="true"
+              className="font-mono text-xs tracking-[0.3em] text-muted mb-4"
+            >
               {"// SYSTEM · SARTHAKSAVVY.EXE"}
             </p>
-            <h1 className="font-display text-3xl sm:text-5xl italic mb-4">
+            {/* Deliberately not an <h1>. This overlay is rendered from the
+                root layout, so a heading here would give every page on the
+                site a second h1 — and it would be the first one in the
+                document, leaving "initializing portfolio" as the strongest
+                heading signal on a page about something else entirely. */}
+            <p
+              id="entry-gate-title"
+              className="font-display text-3xl sm:text-5xl italic mb-4"
+            >
               initializing portfolio
-            </h1>
-            <p className="font-mono text-xs tracking-widest text-muted mb-10">
+            </p>
+            <p
+              id="entry-gate-hint"
+              className="font-mono text-xs tracking-widest text-muted mb-10"
+            >
               SELECT AUDIO STATE TO CONTINUE
-              <span className="animate-blink">_</span>
+              <span aria-hidden="true" className="animate-blink">
+                _
+              </span>
             </p>
             <div className="flex items-center justify-center gap-4">
               <button


### PR DESCRIPTION
## What changed

`EntryGate` is rendered from the root layout, so its `<h1>` landed on **every page of the site**. Two problems followed from that, both fixed here in one file.

### 1. Every route shipped two `<h1>`s

And the one that came first in the document was `initializing portfolio` — not the heading for the page the visitor actually asked for.

Measured in a headless browser against a production build of `main`, on `/about-me`:

```json
{ "h1Count": 2, "h1Texts": ["initializing portfolio", "About me."] }
```

The gate's heading is now a `<p>` carrying the exact same classes, so nothing moves visually. It keeps an `id` and doubles as the overlay's accessible name via `aria-labelledby`.

This matters because the overlay only exists after hydration: the prerendered HTML always had one `<h1>`, so this never showed up in a static check of the build output. Googlebot renders JavaScript, so it sees the post-hydration DOM — the version with two.

### 2. The overlay covered the viewport without behaving like a modal

Three things were broken for anyone not using a mouse:

| | Before | After |
|---|---|---|
| Tab from the gate | 3rd Tab landed on the site logo **behind** the overlay | cycles between the two buttons only |
| Escape | nothing | enters without sound |
| Page behind | kept scrolling | `overflow: hidden`, restored to its previous value on close |
| Focus on open | `document.body` | the SOUND ON button |

`role="dialog"` + `aria-modal="true"` tell a screen reader to ignore the page underneath, instead of reading out a page that is hidden behind an opaque panel. The decorative grid, corner marks and blinking `_` are now `aria-hidden`, so they are not announced.

Closing the gate returns focus to whatever opened it, so **Replay Intro** lands back on that button rather than dropping the visitor at the top of the document.

## Why it helps

- **SEO:** the heading hierarchy on every route now has exactly one `<h1>`, and it describes that page. Previously the first and strongest heading signal on all 12 indexable routes was the same string, which said nothing about the page's subject.
- **Accessibility:** a full-screen blocking overlay with no dialog semantics, no focus containment and no keyboard exit is a WCAG 2.4.3 (focus order) and 2.1.2 (no keyboard trap, inverted — focus *escaped* where it should have been held) problem. These also feed page-experience signals.

## Verification

Both states measured with Playwright against `npm start` on a production build.

**Before** (stashed change, rebuilt):
```json
{ "h1Count": 2, "h1Texts": ["initializing portfolio", "About me."],
  "dialogRole": 0, "bodyOverflow": "", "focusOnOpen": "BODY",
  "tabCycle": ["BUTTON:SOUND ON", "BUTTON:SOUND OFF", "A:Sarthak Shrivastav"] }
```

**After:**
```json
{ "h1Count": 1, "h1Texts": ["About me."],
  "ariaModal": "true", "accessibleName": "initializing portfolio",
  "focusOnOpen": "SOUND ON", "bodyOverflow": "hidden",
  "tabCycle": ["SOUND OFF (inDialog=true)", "SOUND ON (inDialog=true)",
               "SOUND OFF (inDialog=true)", "SOUND ON (inDialog=true)"],
  "dialogAfterEscape": 0, "bodyOverflowAfter": "", "scrolledAfterDismiss": 200 }
```

That last row confirms scrolling works again after dismissal, i.e. the lock is released rather than leaked.

- `npm run build` — passes, 18/18 static pages generated.
- `npm run lint` — no warnings in `EntryGate.js`. The 6 remaining `no-img-element` warnings (`PhotoStack`, `ParticleImage`, `expensorr`) are pre-existing on `main` and untouched here.

## Files touched

- `app/components/EntryGate.js` — the only file changed.

## Notes

- **No visible copy changed.** The gate reads identically and looks identical; `initializing portfolio` keeps its `font-display text-3xl sm:text-5xl italic mb-4` classes, only the tag name changed.
- No dependencies added.
- No TODO placeholders left behind.
- Escape maps to *enter without sound*, which is the conservative default for a dismissal the visitor did not explicitly make a sound choice for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRuRk9rBqRc87a8V7rTqic)_