### PR TITLE
Stop the floating controls from overlapping on mobile

### DIFF
--- a/app/components/FloatingChatWidget.js
+++ b/app/components/FloatingChatWidget.js
@@ -1,79 +1,139 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
-export default function FloatingChatWidget() {
-  const [isOpen, setIsOpen] = useState(false);
+// Open state is owned by FloatingControls so the reset button can move out of
+// the way while the panel is expanded. Positioning lives there too — this
+// component only draws the launcher and the panel.
+export default function FloatingChatWidget({
+  open,
+  onOpenChange,
+  className = "",
+}) {
   const [question, setQuestion] = useState("");
   const router = useRouter();
+  const launcherRef = useRef(null);
+  const inputRef = useRef(null);
+  // The launcher unmounts while the panel is open, so its ref is null exactly
+  // when we want to focus it. Instead we note that focus is owed and hand it
+  // back on the render where the launcher exists again.
+  const focusOwedRef = useRef(false);
+
+  const close = useCallback(() => {
+    focusOwedRef.current = true;
+    onOpenChange(false);
+  }, [onOpenChange]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
     if (question.trim()) {
       router.push(`/ask?q=${encodeURIComponent(question.trim())}`);
       setQuestion("");
-      setIsOpen(false);
+      onOpenChange(false);
     }
   };
 
-  return (
-    <>
-      <div className="fixed bottom-6 right-6 z-50">
-        {!isOpen && (
-          <button
-            onClick={() => setIsOpen(true)}
-            className="bg-ink text-paper px-6 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent transition-all duration-300 shadow-lg hover:shadow-xl flex items-center gap-3 group"
+  // A panel that covers part of the page needs a way out that is not a mouse
+  // aimed at a 12px glyph: Escape closes it, and focus lands in the textarea
+  // on open rather than staying behind on the page underneath.
+  useEffect(() => {
+    if (!open) {
+      if (focusOwedRef.current) {
+        focusOwedRef.current = false;
+        launcherRef.current?.focus();
+      }
+      return;
+    }
+
+    inputRef.current?.focus();
+
+    function onKeyDown(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, close]);
+
+  if (open) {
+    return (
+      <div
+        role="dialog"
+        aria-labelledby="ask-widget-title"
+        className={`pointer-events-auto bg-paper border border-line rounded-2xl p-6 w-full max-w-[20rem] shadow-2xl ${className}`}
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2
+            id="ask-widget-title"
+            className="font-display italic text-lg text-ink"
           >
-            <span>Ask anything about Sarthak</span>
-            <div className="w-2 h-2 bg-accent rounded-full animate-pulse"></div>
+            Ask about Sarthak
+          </h2>
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close ask panel"
+            className="text-muted hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded transition-colors"
+          >
+            <span aria-hidden="true">✕</span>
           </button>
-        )}
+        </div>
 
-        {isOpen && (
-          <div className="bg-paper border border-line rounded-2xl p-6 w-80 shadow-2xl">
-            <div className="flex justify-between items-center mb-4">
-              <h3 className="font-display italic text-lg text-ink">Ask about Sarthak</h3>
-              <button
-                onClick={() => setIsOpen(false)}
-                className="text-muted hover:text-ink transition-colors"
-              >
-                ✕
-              </button>
-            </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <label htmlFor="ask-widget-question" className="sr-only">
+            Your question about Sarthak
+          </label>
+          <textarea
+            id="ask-widget-question"
+            ref={inputRef}
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            placeholder="What would you like to know about Sarthak's background, projects, or expertise?"
+            className="w-full bg-transparent border border-line rounded-lg p-3 text-ink placeholder-muted focus:ring-1 focus:ring-accent focus:border-accent focus:outline-none resize-none"
+            rows={3}
+            maxLength={1000}
+          />
 
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <textarea
-                value={question}
-                onChange={(e) => setQuestion(e.target.value)}
-                placeholder="What would you like to know about Sarthak's background, projects, or expertise?"
-                className="w-full bg-transparent border border-line rounded-lg p-3 text-ink placeholder-muted focus:ring-1 focus:ring-accent focus:border-accent focus:outline-none resize-none"
-                rows={3}
-                maxLength={1000}
-              />
-
-              <div className="flex justify-between items-center">
-                <span className="text-xs text-muted font-mono">
-                  {question.length}/1000
-                </span>
-                <button
-                  type="submit"
-                  disabled={!question.trim()}
-                  className="bg-ink text-paper px-4 py-2 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Ask
-                </button>
-              </div>
-            </form>
-
-            <div className="mt-4 pt-4 border-t border-line">
-              <p className="text-xs text-muted text-center font-mono">
-                Powered by AI · Instant answers about Sarthak&apos;s work
-              </p>
-            </div>
+          <div className="flex justify-between items-center">
+            <span className="text-xs text-muted font-mono">
+              {question.length}/1000
+            </span>
+            <button
+              type="submit"
+              disabled={!question.trim()}
+              className="bg-ink text-paper px-4 py-2 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-paper transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Ask
+            </button>
           </div>
-        )}
+        </form>
+
+        <div className="mt-4 pt-4 border-t border-line">
+          <p className="text-xs text-muted text-center font-mono">
+            Powered by AI · Instant answers about Sarthak&apos;s work
+          </p>
+        </div>
       </div>
-    </>
+    );
+  }
+
+  return (
+    <button
+      ref={launcherRef}
+      type="button"
+      onClick={() => onOpenChange(true)}
+      aria-expanded={false}
+      className={`pointer-events-auto max-w-full text-left bg-ink text-paper px-6 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-paper transition-all duration-300 shadow-lg hover:shadow-xl flex items-center gap-3 ${className}`}
+    >
+      <span>Ask anything about Sarthak</span>
+      <span
+        aria-hidden="true"
+        className="w-2 h-2 shrink-0 bg-accent rounded-full animate-pulse"
+      />
+    </button>
   );
 }

--- a/app/components/FloatingControls.js
+++ b/app/components/FloatingControls.js
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import ResetIntroButton from "./ResetIntroButton";
+import FloatingChatWidget from "./FloatingChatWidget";
+
+// Both floating controls used to position themselves independently — one
+// pinned bottom-left, the other bottom-right. Side by side they need about
+// 500px of room, so on any phone they overlapped: the "Replay Intro" pill sat
+// on top of the "Ask anything about Sarthak" button, hiding half its label and
+// swallowing taps meant for it.
+//
+// Anchoring both to one bar fixes that by making the layout a single decision
+// instead of two independent guesses. The row keeps the original desktop
+// placement exactly (flush to the viewport edges, 24px in); below `sm` it
+// stacks, with the ask button nearest the thumb. Owning `chatOpen` here also
+// lets the reset button step aside while the ask panel is expanded, which is
+// the one case where a stack would still collide.
+export default function FloatingControls() {
+  const [chatOpen, setChatOpen] = useState(false);
+
+  return (
+    // The bar spans the viewport so its children can sit at both edges, which
+    // would otherwise trap every click in the empty middle — hence
+    // pointer-events-none here and pointer-events-auto on the controls.
+    <div className="fixed inset-x-0 bottom-0 z-50 px-6 pb-6 pointer-events-none">
+      <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-end sm:gap-6">
+        {!chatOpen && <ResetIntroButton />}
+        {/* ml-auto rather than justify-between on the row, so hiding the reset
+            button does not slide the ask control across the screen. */}
+        <FloatingChatWidget
+          open={chatOpen}
+          onOpenChange={setChatOpen}
+          className="sm:ml-auto"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/components/ResetIntroButton.js
+++ b/app/components/ResetIntroButton.js
@@ -1,13 +1,15 @@
 "use client";
 
+// Positioning lives in FloatingControls, which lays this out alongside the ask
+// widget; this component only draws the button.
 export default function ResetIntroButton() {
   return (
     <button
       onClick={() => window.dispatchEvent(new Event("gate:reset"))}
-      className="fixed bottom-6 left-6 z-50 bg-paper border border-accent/40 text-ink px-5 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:border-accent hover:bg-accent hover:text-paper transition-colors shadow-lg flex items-center gap-3"
+      className="pointer-events-auto bg-paper border border-accent/40 text-ink px-5 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:border-accent hover:bg-accent hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-paper transition-colors shadow-lg flex items-center gap-3"
     >
       Replay Intro
-      <span className="relative flex h-2 w-2">
+      <span aria-hidden="true" className="relative flex h-2 w-2">
         <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-75" />
         <span className="relative inline-flex rounded-full h-2 w-2 bg-accent" />
       </span>

--- a/app/layout.js
+++ b/app/layout.js
@@ -2,9 +2,8 @@ import localFont from "next/font/local";
 import { Fraunces } from "next/font/google";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
-import FloatingChatWidget from "./components/FloatingChatWidget";
+import FloatingControls from "./components/FloatingControls";
 import EntryGate from "./components/EntryGate";
-import ResetIntroButton from "./components/ResetIntroButton";
 import { SITE_URL } from "./routes";
 import { SITE_NAME, ogImages } from "./seo";
 import "./globals.css";
@@ -66,8 +65,7 @@ export default function RootLayout({ children }) {
           <Header />
           {children}
           <Footer />
-          <FloatingChatWidget />
-          <ResetIntroButton />
+          <FloatingControls />
         </div>
       </body>
     </html>


### PR DESCRIPTION
## The bug

`ResetIntroButton` and `FloatingChatWidget` each pinned themselves to a corner of the viewport independently — `fixed bottom-6 left-6` and `fixed bottom-6 right-6`. Side by side they need about 500px of room, so on any phone they collided. Measured against a production build at 375×667:

| control | x | right |
|---|---|---|
| Replay Intro | 24 | 187 |
| Ask anything about Sarthak | 65 | 351 |

That's a **122px overlap on the same row**, on every page of the site. The reset pill rendered on top, so the label read `REPLAY INTRO ● ABOUT SARTHAK ●`, and taps landing in the shared strip went to whichever button won the stacking order rather than the one under the finger. The site's primary AI-chat CTA was the one being covered. Overlap starts below ~500px viewport width, so it hit every phone.

## The fix

Both controls now live in one `FloatingControls` bar rather than positioning themselves. Making the layout a single decision instead of two independent guesses is what removes the class of bug — nudging one of the two offsets would only have moved the collision to a different width.

- Desktop placement is **unchanged to the pixel** (reset at x=24, ask right edge at viewport−24 — same numbers as before the change).
- Below `sm` the controls stack, ask button nearest the thumb.
- The bar owns the panel's open state, so the reset button steps aside while the ask panel is expanded — the one case a stack would still collide.
- The launcher gets `max-w-full` so it wraps instead of overflowing at 320px.
- `pointer-events-none` on the bar with `pointer-events-auto` on the controls, so the empty middle of the bar doesn't eat clicks meant for the page.

## Accessibility, while the widget was open on the operating table

The ask widget was unusable without a mouse:

- Escape now closes the panel; focus moves into the textarea on open and returns to the launcher on close.
- The close control had no accessible name — screen readers announced the bare `✕` glyph. It's now `aria-label="Close ask panel"`.
- The textarea had no label (placeholder only); it now has a real `<label>`.
- The panel is a labelled `role="dialog"`; the launcher exposes `aria-expanded`.
- Decorative pulsing dots are `aria-hidden`.
- Added visible `focus-visible` rings on the controls, which had none.

## Verification

Automated pass with Playwright at 320/360/375/1280px against `next build && next start`:

```
320x640   OVERLAP=false  hScroll=false
375x667   OVERLAP=false  hScroll=false
360x740   OVERLAP=false  hScroll=false
1280x800  OVERLAP=false  hScroll=false

panel open, focus lands on            = ask-widget-question
reset button rendered while open      = 0
close button has accessible name      = yes
dialog exposes its label              = yes
Escape closes panel                   = true
Escape returns focus to launcher      = true
```

- `npm run build` — passes.
- `npm run lint` — clean. The only warnings are the four pre-existing `no-img-element` ones in `ParticleImage.js` and `side-projects/expensorr/page.js`; none in the files touched here.

## Files touched

- `app/components/FloatingControls.js` — new; owns positioning and the panel's open state.
- `app/components/FloatingChatWidget.js` — open state lifted out, positioning removed, accessibility fixes.
- `app/components/ResetIntroButton.js` — positioning removed, decorative dots hidden, focus ring added.
- `app/layout.js` — renders `<FloatingControls />` in place of the two components.

No dependencies added. No TODO placeholders left behind.

## NEEDS APPROVAL

**NEEDS APPROVAL: public-facing UI.** No copy changed — every visible string is byte-identical, and no claims, links, or positioning about Sarthak were touched. But this does change how the site looks on mobile for every visitor (the controls stack instead of sharing one row), which puts it on the boundary of the "anything a visitor reads as a statement from Sarthak" rule. Flagging rather than self-merging; it's a one-click merge if the mobile stacking looks right to you.