### PR TITLE
Fix a dead CTA, 453KB of QR codes, and footer nav reloads

### DIFF
--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -8,11 +8,30 @@ const links = [
   { href: "/about-me", label: "About Me" },
 ];
 
+// The icon is the whole of each link, so its alt text is the only accessible
+// name the link has. "x" on its own tells a screen reader nothing; the label
+// below is what gets read out instead.
 const socials = [
-  { href: "https://linkedin.com/in/sarthaksavvy", icon: "linkedin" },
-  { href: "https://github.com/sarthaksavvy", icon: "github" },
-  { href: "https://instagram.com/sarthaksavvy", icon: "instagram" },
-  { href: "https://x.com/sarthaksavvy", icon: "x" },
+  {
+    href: "https://linkedin.com/in/sarthaksavvy",
+    icon: "linkedin",
+    label: "Sarthak Shrivastava on LinkedIn",
+  },
+  {
+    href: "https://github.com/sarthaksavvy",
+    icon: "github",
+    label: "Sarthak Shrivastava on GitHub",
+  },
+  {
+    href: "https://instagram.com/sarthaksavvy",
+    icon: "instagram",
+    label: "Sarthak Shrivastava on Instagram",
+  },
+  {
+    href: "https://x.com/sarthaksavvy",
+    icon: "x",
+    label: "Sarthak Shrivastava on X",
+  },
 ];
 
 export default function Footer() {
@@ -40,7 +59,12 @@ export default function Footer() {
                 rel="noreferrer"
                 className="w-11 h-11 rounded-full border border-ink/20 flex items-center justify-center hover:border-ink hover:bg-ink hover:[&_img]:invert transition-colors"
               >
-                <Image src={`/images/icons/${s.icon}.svg`} alt={s.icon} width={18} height={18} />
+                <Image
+                  src={`/images/icons/${s.icon}.svg`}
+                  alt={s.label}
+                  width={18}
+                  height={18}
+                />
               </a>
             ))}
           </div>
@@ -50,15 +74,13 @@ export default function Footer() {
           <span>© {new Date().getFullYear()} SARTHAK SHRIVASTAVA</span>
           <div className="flex gap-6 flex-wrap justify-center">
             {links.map((l) => (
-              <a
+              <Link
                 key={l.href}
                 href={l.href}
-                target={l.external ? "_blank" : undefined}
-                rel={l.external ? "noreferrer" : undefined}
                 className="hover:text-ink transition-colors"
               >
                 {l.label.toUpperCase()}
-              </a>
+              </Link>
             ))}
           </div>
           <span>BUILT IN INDIA</span>

--- a/app/side-projects/expensorr/page.js
+++ b/app/side-projects/expensorr/page.js
@@ -8,6 +8,7 @@ import {
   Smartphone,
   Star,
 } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 import JsonLd from "../../components/JsonLd";
 import { ogImages, pageMetadata } from "../../seo";
@@ -18,6 +19,11 @@ import {
 } from "../../structuredData";
 
 const SITE = "https://apps.apple.com/us/app/expensorr/id6739472004";
+
+// The QR sources are 1000x1000 but land in a 192px box with 16px of padding
+// on each side. Declaring the size they are actually drawn at is what lets
+// next/image ship a thumbnail instead of the full-resolution original.
+const QR_RENDERED_SIZE = 160;
 
 const DESCRIPTION =
   "Expensorr is a simple yet powerful expense tracking application that helps you monitor and manage your personal finances with ease.";
@@ -117,7 +123,7 @@ export default function ExpensorrProject() {
             </p>
             <div className="flex flex-wrap gap-4">
               <a
-                href="https://apps.apple.com/us/app/expensorr/id6739472004"
+                href={SITE}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 bg-ink text-paper px-6 py-3 rounded-full font-medium hover:bg-accent transition-colors"
@@ -134,14 +140,21 @@ export default function ExpensorrProject() {
               </a>
             </div>
           </div>
-          <div className="relative h-80 rounded-3xl overflow-hidden shadow-xl bg-paper border border-line p-6">
+          {/* The "Get App" button above links here, so this panel owns the
+              #download target. */}
+          <div
+            id="download"
+            className="relative h-80 scroll-mt-24 rounded-3xl overflow-hidden shadow-xl bg-paper border border-line p-6"
+          >
             <div className="grid grid-cols-2 h-full gap-4">
               {/* iOS QR Code */}
               <div className="flex flex-col items-center justify-center">
                 <div className="relative h-48 w-48 mb-3 bg-white p-4 rounded-xl">
-                  <img
+                  <Image
                     src="/images/projects/qr/expensorr-ios.jpg"
-                    alt="iOS QR Code"
+                    alt="QR code linking to Expensorr on the App Store"
+                    width={QR_RENDERED_SIZE}
+                    height={QR_RENDERED_SIZE}
                     className="object-contain h-full w-full"
                   />
                 </div>
@@ -151,9 +164,11 @@ export default function ExpensorrProject() {
               {/* Android QR Code */}
               <div className="flex flex-col items-center justify-center">
                 <div className="relative h-48 w-48 mb-3 bg-white p-4 rounded-xl">
-                  <img
+                  <Image
                     src="/images/projects/qr/expensorr-android.jpg"
-                    alt="Android QR Code"
+                    alt="QR code linking to Expensorr on Google Play"
+                    width={QR_RENDERED_SIZE}
+                    height={QR_RENDERED_SIZE}
                     className="object-contain h-full w-full"
                   />
                 </div>
@@ -335,8 +350,9 @@ export default function ExpensorrProject() {
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <a
-              href="https://apps.apple.com/us/app/expensorr/id6739472004"
+              href={SITE}
               target="_blank"
+              rel="noopener noreferrer"
               className="bg-ink text-paper px-8 py-3 rounded-full font-medium hover:bg-accent transition-colors inline-flex items-center gap-2"
             >
               Download Now


### PR DESCRIPTION
Three visitor-facing defects found while auditing the site. None of them change any copy a visitor reads.

## What changed

**The "Get App" button on the Expensorr page did nothing.** It links to `#download`, but no element on that page had that `id` — I checked every project page, and Expensorr is the only one where the in-page anchor has no target (ginger, audiobolo and backstage-cut all have a real `#features` section). The QR panel beside the button is what the button is asking for, so it now owns the `#download` target, with `scroll-mt-24` so the sticky header doesn't cover it on mobile.

**Both QR codes were shipping at full resolution.** They were raw `<img>` tags pointing at 1000×1000 sources drawn into a 160px box — 453KB of image in the hero region of a page whose entire JS budget is 99KB. Routed through `next/image` they come back as WebP thumbnails. Measured against a production build:

| | before | after |
|---|---|---|
| `expensorr-ios.jpg` | 239,224 B (JPEG) | 19,704 B (WebP, 256w) |
| `expensorr-android.jpg` | 224,291 B (JPEG) | ~20 KB (WebP, 256w) |

Worth knowing: **both files are actually PNGs despite the `.jpg` extension** (magic bytes `89504e47`). Browsers sniff the content so it renders fine, and `next/image` handles it correctly, so nothing is broken — but the names are misleading if anyone touches them later.

**Footer links reloaded the whole page.** The footer's internal links were plain `<a>` tags, so every click out of the footer tore down the app and re-fetched the document instead of navigating client-side. They're `next/link` now. That also removes a dead `l.external` reference — no entry in that array has the key, so both ternaries always resolved to `undefined`.

Two smaller items picked up along the way:
- The social icons' `alt` was the bare icon name, so a screen reader announced the X link as just "x". The icon is the entire content of each link, so its alt text is the link's only accessible name; it now says where the link goes.
- The second App Store button was missing the `rel="noopener noreferrer"` that its twin higher up the same page already had. Both now reference the existing `SITE` constant instead of repeating the URL.

## Why it helps

The dead CTA and the reloading footer are straightforward bugs — a visitor clicks and gets nothing, or gets a blank flash and a cold start. The image fix is Core Web Vitals: 453KB of above-the-fold image is the LCP on that page, and it's now ~40KB. The alt text is an accessibility fix that also gives crawlers something meaningful to read on four outbound profile links.

## Files touched

- `app/side-projects/expensorr/page.js` — anchor target, `next/image`, `rel`, `SITE` reuse
- `app/components/Footer.js` — `next/link`, descriptive alt text, dead `external` branch removed

## Build / lint

- `npm ci` — clean
- `npm run build` — passes, all 18 routes still prerender
- `npm run lint` — no ESLint warnings or errors
- Verified against `npm run start`: `id="download"` present and matching `href="#download"`, both QR codes serving through `/_next/image`, byte counts as measured above

No TODO placeholders left behind.

## One thing I did not touch

While reading that page I noticed the **"User Testimonials" section contains three reviews attributed to named people** ("John D.", "Sarah M.", "Michael T.") with star ratings, for a real app that's live on the US App Store. I have no way to tell from the repo whether those are real quotes or placeholder text that shipped, and it's your public copy either way, so I left it exactly as it is. If it's placeholder, it's worth removing — flagging it rather than editing it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQRbUY6zV7UEtKdroXjCyR)_