### PR TITLE
Fix stale answers on /ask, plus lost focus and silent state changes

### DIFF
--- a/app/ask/page.js
+++ b/app/ask/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, Suspense } from "react";
+import { useCallback, useEffect, useRef, useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
@@ -72,6 +72,11 @@ const markdownComponents = {
   hr: () => <hr className="border-line my-8" />,
 };
 
+// Matches the `maxLength` on the textarea and the ceiling the API enforces.
+const MAX_QUESTION_LENGTH = 1000;
+// Longer answers need more headroom than a typical fetch timeout allows.
+const REQUEST_TIMEOUT_MS = 45000;
+
 const POPULAR_QUESTIONS = [
   "What are Sarthak's main areas of expertise?",
   "Tell me about Sarthak's side projects",
@@ -87,64 +92,125 @@ function AskPageContent() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const searchParams = useSearchParams();
+  const resultsRef = useRef(null);
+  // Every request takes a ticket. Only the holder of the current ticket is
+  // allowed to write to state, so a superseded request cannot resolve late and
+  // overwrite the answer to the question the visitor is actually reading.
+  const requestTicketRef = useRef(0);
+  const activeRequestRef = useRef(null);
+
+  const cancelActiveRequest = useCallback(() => {
+    requestTicketRef.current += 1;
+
+    const active = activeRequestRef.current;
+    if (!active) return;
+
+    clearTimeout(active.timeoutId);
+    active.controller.abort();
+    activeRequestRef.current = null;
+  }, []);
+
+  const handleAskQuestion = useCallback(
+    async (questionText) => {
+      const trimmed = questionText.trim();
+      if (!trimmed) return;
+
+      // The floating ask widget is rendered from the root layout, so it is on
+      // this page too: asking from it while an answer is still loading used to
+      // leave two requests racing, and the slower one won. That could settle
+      // the page on the previous question's answer, displayed underneath the
+      // new question's text, with no way to tell the two apart.
+      cancelActiveRequest();
+      const ticket = requestTicketRef.current;
+      const isCurrent = () => requestTicketRef.current === ticket;
+
+      setLoading(true);
+      setError("");
+      setAnswer("");
+
+      // Submitting disables both the textarea and the button, and a disabled
+      // element cannot hold focus — so the browser dropped the keyboard
+      // visitor back onto <body> and they had to tab in from the top of the
+      // document again. Moving focus to the results panel keeps them where the
+      // page is about to change, and gives a screen reader the progress text.
+      resultsRef.current?.focus();
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        REQUEST_TIMEOUT_MS
+      );
+      activeRequestRef.current = { controller, timeoutId };
+
+      try {
+        const response = await fetch("/api/ask", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ question: trimmed }),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+
+          if (response.status === 429) {
+            throw new Error(errorData.error || "Too many requests. Please wait before asking another question.");
+          } else if (response.status === 400) {
+            throw new Error(errorData.error || "Invalid question format.");
+          } else if (response.status === 408) {
+            throw new Error("Request timeout. Please try again with a shorter question.");
+          } else {
+            throw new Error(errorData.error || "Failed to get answer");
+          }
+        }
+
+        const data = await response.json();
+        if (!isCurrent()) return;
+        setAnswer(data.answer);
+      } catch (err) {
+        // A superseded or unmounted request aborts by design. Reporting that
+        // as a failure would put a timeout message on screen at the exact
+        // moment the replacement request is working correctly.
+        if (!isCurrent()) return;
+
+        if (err.name === 'AbortError') {
+          setError("Request timeout. Please try again with a shorter question.");
+        } else {
+          setError(err.message || "Sorry, I couldn't process your question right now. Please try again.");
+        }
+        console.error("Error:", err);
+      } finally {
+        // Cleared here rather than only on the success path, where a failed
+        // request left its 45s timer running with the controller still
+        // referenced by it.
+        clearTimeout(timeoutId);
+        if (activeRequestRef.current?.controller === controller) {
+          activeRequestRef.current = null;
+        }
+        if (isCurrent()) setLoading(false);
+      }
+    },
+    [cancelActiveRequest]
+  );
 
   useEffect(() => {
     const q = searchParams.get("q");
-    if (q) {
-      setQuestion(q);
-      handleAskQuestion(q);
-    }
-  }, [searchParams]);
+    if (!q) return;
 
-  const handleAskQuestion = async (questionText) => {
-    if (!questionText.trim()) return;
+    // `maxLength` only constrains typing, so a shared or hand-edited `?q=` can
+    // arrive longer than the API accepts. Left as-is it seeded the box with a
+    // question the counter read as "1400/1000" and every submit came back as a
+    // 400, with no hint that the length was the problem.
+    const seeded = q.slice(0, MAX_QUESTION_LENGTH);
+    setQuestion(seeded);
+    handleAskQuestion(seeded);
+  }, [searchParams, handleAskQuestion]);
 
-    setLoading(true);
-    setError("");
-    setAnswer("");
-
-    try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 45000); // 45s — longer answers need more headroom
-
-      const response = await fetch("/api/ask", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ question: questionText }),
-        signal: controller.signal,
-      });
-
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-
-        if (response.status === 429) {
-          throw new Error(errorData.error || "Too many requests. Please wait before asking another question.");
-        } else if (response.status === 400) {
-          throw new Error(errorData.error || "Invalid question format.");
-        } else if (response.status === 408) {
-          throw new Error("Request timeout. Please try again with a shorter question.");
-        } else {
-          throw new Error(errorData.error || "Failed to get answer");
-        }
-      }
-
-      const data = await response.json();
-      setAnswer(data.answer);
-    } catch (err) {
-      if (err.name === 'AbortError') {
-        setError("Request timeout. Please try again with a shorter question.");
-      } else {
-        setError(err.message || "Sorry, I couldn't process your question right now. Please try again.");
-      }
-      console.error("Error:", err);
-    } finally {
-      setLoading(false);
-    }
-  };
+  // Navigating away mid-answer should stop the request, not let it run to
+  // completion against a page nobody is looking at.
+  useEffect(() => cancelActiveRequest, [cancelActiveRequest]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -220,47 +286,78 @@ function AskPageContent() {
           </form>
         </Reveal>
 
-        {/* Answer Section */}
-        {(loading || answer || error) && (
-          <div className="border border-line rounded-3xl p-8 sm:p-10 mb-10">
-            <h2 className="text-xs font-mono uppercase tracking-widest mb-6 text-muted">
-              Answer
-            </h2>
+        {/* Answer Section. The wrapper stays mounted even when there is
+            nothing to show: it has to exist before it can take focus on
+            submit, and a live region that appears in the same paint as its
+            first message is not reliably announced. */}
+        <div
+          ref={resultsRef}
+          tabIndex={-1}
+          aria-busy={loading}
+          className="focus:outline-none"
+        >
+          {/* The answer replaces the panel contents without moving focus or
+              scrolling, so nothing signals to a screen reader that the page
+              responded. This carries the state change as one short sentence,
+              rather than making the whole panel live and having it read a
+              several-hundred-word answer aloud unprompted. */}
+          <p aria-live="polite" className="sr-only">
+            {loading
+              ? "Searching through Sarthak's information."
+              : error
+                ? `That question could not be answered. ${error}`
+                : answer
+                  ? "The answer is ready, below the question box."
+                  : ""}
+          </p>
 
-            {loading && (
-              <div className="flex items-center gap-3 text-ink/60">
-                <span className="w-4 h-4 border-2 border-accent border-t-transparent rounded-full animate-spin" />
-                <span className="font-mono text-xs tracking-widest uppercase">
-                  Searching through Sarthak&apos;s information
-                </span>
-              </div>
-            )}
+          {(loading || answer || error) && (
+            <div className="border border-line rounded-3xl p-8 sm:p-10 mb-10">
+              <h2 className="text-xs font-mono uppercase tracking-widest mb-6 text-muted">
+                Answer
+              </h2>
 
-            {error && (
-              <div className="border border-accent/40 bg-accent/5 text-ink/80 rounded-2xl p-5">
-                {error}
-              </div>
-            )}
+              {loading && (
+                <div className="flex items-center gap-3 text-ink/60">
+                  <span
+                    aria-hidden="true"
+                    className="w-4 h-4 border-2 border-accent border-t-transparent rounded-full animate-spin"
+                  />
+                  <span className="font-mono text-xs tracking-widest uppercase">
+                    Searching through Sarthak&apos;s information
+                  </span>
+                </div>
+              )}
 
-            {answer && (
-              <div className="text-lg text-ink/80 leading-relaxed">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  components={markdownComponents}
-                >
-                  {answer}
-                </ReactMarkdown>
-              </div>
-            )}
-          </div>
-        )}
+              {error && (
+                <div className="border border-accent/40 bg-accent/5 text-ink/80 rounded-2xl p-5">
+                  {error}
+                </div>
+              )}
+
+              {answer && (
+                <div className="text-lg text-ink/80 leading-relaxed">
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={markdownComponents}
+                  >
+                    {answer}
+                  </ReactMarkdown>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
 
         {/* Suggested Questions */}
         {!loading && !answer && !error && (
           <div className="mb-20">
-            <h3 className="text-xs font-mono uppercase tracking-widest mb-6 text-muted">
+            {/* An h2, not an h3: this is a top-level section of the page,
+                sibling to "Answer". As an h3 it skipped a level, because it
+                only ever renders when the "Answer" h2 is absent. */}
+            <h2 className="text-xs font-mono uppercase tracking-widest mb-6 text-muted">
               Popular Questions
-            </h3>
+            </h2>
             <StaggerGroup className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {POPULAR_QUESTIONS.map((suggestedQ) => (
                 <StaggerItem key={suggestedQ}>


### PR DESCRIPTION
## What changed

Five defects on `/ask`, all in `app/ask/page.js`.

**1. Overlapping requests could show the wrong answer.** Asking a second question while the first was still loading left two requests in flight with no ordering guard — both called `setAnswer`, so the slower one won. The floating ask widget is rendered from the root layout, so it is present on `/ask` itself; opening it mid-answer is the ordinary way a visitor hits this. The result was the *previous* question's answer sitting underneath the *new* question's text, with nothing to tell them apart.

Requests now take a ticket. Only the holder of the current ticket may write to state, and starting a question aborts whatever was in flight. The same guard stops a deliberate abort from surfacing as a "Request timeout" error at the exact moment the replacement request is working correctly.

**2. Leaked timers.** The 45s abort timer was cleared only on the success path, so every failed request left a timer running with its `AbortController` still referenced by it. Now cleared in `finally`, and the in-flight request is aborted on unmount rather than running to completion against a page nobody is looking at.

**3. Focus was dumped on `<body>` after every submit.** Submitting disables both the textarea and the button, and a disabled element cannot hold focus — so the browser dropped keyboard visitors onto `<body>` and they had to tab in from the top of the document to reach the answer. Focus now moves to the results panel.

**4. Nothing announced that the page had responded.** No focus change, no scroll, no live region — a screen reader user submitted a question and got silence, both while waiting and when the answer landed. A short `aria-live="polite"` status now carries the state change, and the panel gets `aria-busy`. Deliberately a one-sentence status rather than making the whole panel live, which would read a several-hundred-word markdown answer aloud unprompted.

**5. An over-long `?q=` produced a dead form.** `maxLength` only constrains typing, not a programmatically set value, so a shared or hand-edited `?q=` longer than the API accepts seeded a box whose counter read `1400/1000` and for which every submit returned a 400 — with no hint that length was the problem. Capped to the same 1000-character limit the API enforces.

Also: `Popular Questions` was an `h3` with no `h2` above it — it only ever renders when the `Answer` `h2` is absent, so the page went `h1 → h3`. Now an `h2`. Tailwind preflight resets heading sizes and the classes are unchanged, so it renders identically.

## Why it helps

(1) and (5) are correctness bugs a visitor can trip over on the site's flagship interactive feature — one shows factually wrong output. (3) and (4) make `/ask` usable by keyboard and screen-reader visitors, which is also an accessibility signal search engines weigh. (2) is a resource leak. The heading fix restores a valid document outline for crawlers.

## Files touched

- `app/ask/page.js` — the only file changed.

No new dependencies, no config changes, no changes to `app/api/ask/route.js` or any server-side validation.

## Build and lint

- `npm ci` — clean
- `npm run lint` — `✔ No ESLint warnings or errors`
- `npm run build` — passes; `/ask` 46.8 kB → 47.1 kB first-load JS

## Verified in a browser

Ran a Playwright check against a production build with the API stubbed, on the code before and after the change:

| Check | Before | After |
| --- | --- | --- |
| Slow question superseded by a fast one | shows `SLOW` answer ❌ | shows `FAST` answer ✅ |
| `document.activeElement` after submit | `BODY` ❌ | results panel ✅ |
| Live region present | none ❌ | present, announces ✅ |
| Counter for a 1400-char `?q=` | `1400/1000` ❌ | `1000/1000` ✅ |
| Heading outline | `h1 → h3` ❌ | `h1 → h2` ✅ |

Screenshotted the idle and answered states: layout, spacing and styling are unchanged, and the programmatically focused panel shows no focus ring.

## TODO placeholders

None.

## Merge bucket

Purely technical: correctness, resource cleanup, accessibility attributes and focus management, and one semantic heading level. No visible copy changed and no claims about Sarthak were added or altered — the only new strings are screen-reader status text describing UI state, one of which already exists verbatim on screen. No dependency, deployment-config, or server-side/security changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZPAhQXPoeo5r3QmfTmqk7)_