### PR TITLE
Fix MagneticButton swallowing clicks on every CTA

### DIFF
--- a/app/components/motion/MagneticButton.js
+++ b/app/components/motion/MagneticButton.js
@@ -1,26 +1,72 @@
 "use client";
 
-import { useRef, useState } from "react";
-import { motion } from "framer-motion";
+import { useRef } from "react";
+import { motion, useMotionValue, useSpring } from "framer-motion";
 
-export default function MagneticButton({ children, className = "", as: Tag = "a", ...props }) {
+// How far the element follows the cursor, as a fraction of the distance from
+// its centre, and the spring that carries it there. Unchanged from the values
+// the button has always used, so the effect looks exactly the same.
+const PULL = 0.35;
+const SPRING = { stiffness: 150, damping: 12, mass: 0.5 };
+
+// This used to call `motion(Tag)` inline in the render body. Both that and its
+// replacement, `motion.create(Tag)`, mint a brand new component *type* on every
+// call, and React treats a new type as a different element: it unmounts the old
+// subtree and mounts a fresh one in its place. Building the type during render
+// therefore threw away and rebuilt this button's DOM node on every render — and
+// with the cursor position held in state, that meant every mousemove.
+//
+// That was not just wasteful. A click only fires if its mousedown and its
+// mouseup land on the same node, so a single mousemove delivered while the
+// button was held replaced the node mid-press and the browser fired no click at
+// all. Every MagneticButton on the site is a link — "Book a Call", "View Work",
+// "Get in Touch", the podcast and project links — and each of them silently
+// dropped clicks for anyone whose hand was not perfectly still.
+//
+// Caching by tag keeps one stable type per element kind for the life of the
+// module, which is what lets the node survive across renders.
+const motionTags = new Map();
+
+function motionTag(tag) {
+  let component = motionTags.get(tag);
+  if (!component) {
+    component = motion.create(tag);
+    motionTags.set(tag, component);
+  }
+  return component;
+}
+
+export default function MagneticButton({
+  children,
+  className = "",
+  as: Tag = "a",
+  style,
+  ...props
+}) {
   const ref = useRef(null);
-  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const MotionTag = motionTag(Tag);
+
+  // Motion values are written to the DOM directly rather than through state, so
+  // tracking the cursor no longer re-renders the component ~60 times a second.
+  // Same approach as TiltCard: the pointer sets the *target*, and the spring
+  // that the element actually renders follows it.
+  const targetX = useMotionValue(0);
+  const targetY = useMotionValue(0);
+  const x = useSpring(targetX, SPRING);
+  const y = useSpring(targetY, SPRING);
 
   function handleMouseMove(e) {
     const el = ref.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
-    const x = e.clientX - rect.left - rect.width / 2;
-    const y = e.clientY - rect.top - rect.height / 2;
-    setPos({ x: x * 0.35, y: y * 0.35 });
+    targetX.set((e.clientX - rect.left - rect.width / 2) * PULL);
+    targetY.set((e.clientY - rect.top - rect.height / 2) * PULL);
   }
 
   function handleMouseLeave() {
-    setPos({ x: 0, y: 0 });
+    targetX.set(0);
+    targetY.set(0);
   }
-
-  const MotionTag = motion(Tag);
 
   return (
     <MotionTag
@@ -28,8 +74,7 @@ export default function MagneticButton({ children, className = "", as: Tag = "a"
       className={className}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
-      animate={{ x: pos.x, y: pos.y }}
-      transition={{ type: "spring", stiffness: 150, damping: 12, mass: 0.5 }}
+      style={{ ...style, x, y }}
       {...props}
     >
       {children}


### PR DESCRIPTION
## What changed

`MagneticButton` built its motion component with `motion(Tag)` **inside the render body**:

```js
const MotionTag = motion(Tag);   // new component type on every render
```

`motion()` (and its v12 replacement `motion.create()`) mints a brand new component *type* on every call. React treats a new type as a different element, so it unmounts the old subtree and mounts a fresh one — the button's DOM node was destroyed and rebuilt on **every render**. Cursor position was held in `useState`, so "every render" meant every `mousemove`.

The fix does two things:

1. Hoists the motion component into a module-level cache keyed by tag, so there is one stable type per element kind and the DOM node survives across renders.
2. Moves the cursor position onto `useMotionValue` + `useSpring` — the same pattern `TiltCard` already uses in this repo — so tracking the cursor writes straight to the DOM and no longer re-renders the component at all.

`PULL` (0.35) and the spring config (`stiffness: 150, damping: 12, mass: 0.5`) are carried over unchanged, so the effect looks and feels exactly as before.

## Why it matters

This was not just a wasted-render problem. **A click only fires if its `mousedown` and its `mouseup` land on the same node.** A single `mousemove` delivered while the button was held replaced the node mid-press, and the browser fired no `click` at all — so the link never navigated.

Every `MagneticButton` on the site is a link, and there are 18 of them across 6 files, including essentially every conversion path:

- **"Book a Call"** → cal.com (the primary CTA on the homepage and `/about-me`)
- **"View Work"** → `/side-projects`
- **"Get in Touch"** → mailto, on `/about-me` and the "Want me to speak at your event?" block on `/public-speaking`
- The Apple Podcasts / Spotify / YouTube links on `/podcasts`
- The live-site and case-study links on `/side-projects`

## How it was verified

Driven with Playwright against a `next build && next start` production build, comparing `main` and this branch on the same machine.

**Does the DOM node survive hovering?**

| | `main` | this branch |
|---|---|---|
| node still attached after 12 mousemoves over the button | ❌ detached | ✅ attached |

**Does a click on "View Work" navigate?**

| press style | `main` | this branch |
|---|---|---|
| perfectly still press (zero mousemove between down and up) | ✅ navigates | ✅ navigates |
| **one mousemove while the button is held** | ❌ **no click event, no navigation** | ✅ navigates |

The second row is the realistic case — a hand on a mouse, and effectively always on a trackpad, emits `mousemove` during a click.

Also confirmed on this branch:

- "Book a Call" opens its new tab on a press-with-movement (cal.com itself is unreachable from the sandbox, but the tab opens, so the click fires and navigation is attempted).
- The magnetic effect still works: hovering near the edge of "View Work" yields `transform: translateX(13.8px) translateY(-3px)`, and the node stays attached. Spot-checked the same on `/public-speaking` and `/about-me`.

Note: a drag of more than ~5px between press and release cancels the click in *any* build — that is Chromium's native link-drag threshold, not a site bug. All measurements above stay under it.

## Files touched

- `app/components/motion/MagneticButton.js` (only file changed)

## Build / lint status

- `npm ci` — clean
- `npm run build` — ✅ passes
- `npm run lint` — ✅ no ESLint warnings or errors

## TODOs left behind

None.

## Merge bucket

Purely technical: one client component's internals. No visible copy, no dependencies, no config, no security surface, no personal information. The rendered markup, classes and animation parameters are identical — the only user-visible difference is that the links now respond to clicks.

---
_Generated by [Claude Code](https://claude.ai/code/session_014UwouvZEXku1jU4qbrzoWY)_