### PR TITLE
Give every page a main landmark and a skip link

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -57,7 +57,10 @@ export default function Header() {
         scrolled ? "bg-paper/85 backdrop-blur-md border-b border-line" : "bg-transparent"
       }`}
     >
-      <nav className="flex justify-between items-center px-6 sm:px-10 py-5 sm:py-6 max-w-[1400px] mx-auto w-full">
+      <nav
+        aria-label="Primary"
+        className="flex justify-between items-center px-6 sm:px-10 py-5 sm:py-6 max-w-[1400px] mx-auto w-full"
+      >
         <Link href="/" className="font-display italic text-lg sm:text-xl">
           Sarthak Shrivastava
         </Link>
@@ -68,10 +71,17 @@ export default function Header() {
           ))}
         </div>
 
+        {/* The three bars animate into a cross, which is the only signal that
+            the menu is open — and it is a purely visual one. aria-expanded is
+            what carries that same state to a screen reader, and aria-controls
+            ties the button to the panel it opens. */}
         <button
+          type="button"
           onClick={() => setIsOpen(!isOpen)}
           className="md:hidden relative z-40 w-8 h-6 flex flex-col justify-between"
-          aria-label="Toggle menu"
+          aria-label={isOpen ? "Close menu" : "Open menu"}
+          aria-expanded={isOpen}
+          aria-controls="mobile-nav"
         >
           <motion.span
             animate={isOpen ? { rotate: 45, y: 10 } : { rotate: 0, y: 0 }}
@@ -91,13 +101,17 @@ export default function Header() {
       <AnimatePresence>
         {isOpen && (
           <motion.div
+            id="mobile-nav"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
             transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
             className="md:hidden overflow-hidden bg-paper border-b border-line"
           >
-            <div className="flex flex-col gap-6 px-6 py-8">
+            {/* A landmark of its own: the panel renders outside the primary
+                nav above, so without this the mobile links sit in no landmark
+                at all. */}
+            <nav aria-label="Primary mobile" className="flex flex-col gap-6 px-6 py-8">
               {navLinks.map((link, i) => (
                 <motion.div
                   key={link.label}
@@ -115,7 +129,7 @@ export default function Header() {
                   </Link>
                 </motion.div>
               ))}
-            </div>
+            </nav>
           </motion.div>
         )}
       </AnimatePresence>

--- a/app/components/Hero.js
+++ b/app/components/Hero.js
@@ -9,7 +9,10 @@ const ParticleImage = dynamic(() => import("./motion/ParticleImage"), { ssr: fal
 
 export default function Hero() {
   return (
-    <main className="relative px-6 sm:px-10 max-w-[1400px] mx-auto pt-6 sm:pt-10 pb-20 min-h-[90vh]">
+    // Was a <main>. The landmark now comes from the root layout, so keeping
+    // one here would nest a second one inside it and split the home page's
+    // content across two landmarks with the same name.
+    <section className="relative px-6 sm:px-10 max-w-[1400px] mx-auto pt-6 sm:pt-10 pb-20 min-h-[90vh]">
       <div className="hidden md:block absolute right-[2%] top-[2%] w-[42%] h-[70vh] max-h-[640px] z-10">
         <ParticleImage src="/images/sarthak.jpg" className="w-full h-full" />
       </div>
@@ -93,6 +96,6 @@ export default function Hero() {
           <span className="md:text-right">Bitfumes Founder</span>
         </motion.div>
       </div>
-    </main>
+    </section>
   );
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -62,8 +62,27 @@ export default function RootLayout({ children }) {
       <body className="grain">
         <EntryGate />
         <div className="min-h-screen bg-paper text-ink w-full overflow-x-hidden">
+          {/* Header, footer and the two floating controls sit outside the main
+              landmark on purpose: everything in here is repeated on every
+              route, so a screen reader or keyboard visitor needs a way past it
+              that is not seven Tab presses. The link is invisible until it is
+              focused, at which point it is the first thing in the tab order. */}
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[110] focus:px-5 focus:py-3 focus:rounded-full focus:bg-ink focus:text-paper focus:font-mono focus:text-xs focus:tracking-widest focus:uppercase focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-paper"
+          >
+            Skip to content
+          </a>
           <Header />
-          {children}
+          {/* The landmark lives here rather than in each page so no route can
+              ship without one — before this only the home page had a <main>,
+              which left every other page with no content landmark at all.
+              tabIndex makes it a valid destination for the skip link: without
+              it the browser moves the viewport but leaves focus behind, and
+              the next Tab returns to the top of the header. */}
+          <main id="main-content" tabIndex={-1} className="focus:outline-none">
+            {children}
+          </main>
           <Footer />
           <FloatingControls />
         </div>


### PR DESCRIPTION
## What changed

**The `<main>` landmark existed on exactly one page.** It was declared inside `Hero`, so it only ever rendered on `/`. Every other route — `/about-me`, `/podcasts`, `/public-speaking`, `/ask`, `/side-projects` and all five project pages — shipped its content in bare `<div>`s with no content landmark.

- `app/layout.js` — `<main id="main-content" tabIndex={-1}>` now wraps `{children}`, so no route can ship without one. Added a skip link ahead of the header: `sr-only` until focused, then a normal paper-theme pill.
- `app/components/Hero.js` — its `<main>` becomes a `<section>`, same classes. Without this the home page would nest two landmarks.
- `app/components/Header.js` — the hamburger animates into a cross, which was the only signal that the menu was open, and a purely visual one. It now carries `aria-expanded` / `aria-controls` and names itself "Open menu" / "Close menu". The desktop nav gets `aria-label="Primary"`; the mobile panel's links get a `<nav>` of their own, since they render outside the desktop nav and so were in no landmark either.

## Why it helps

- **Landmark navigation works again.** Screen reader users navigate by landmark (`D` in NVDA, rotor in VoiceOver). On nine of ten pages there was nothing to navigate to.
- **Keyboard users get past the header.** Previously every page load meant tabbing through six nav links before reaching content. `tabIndex={-1}` on the target matters here — without it browsers scroll the viewport but leave focus in the header, so the next Tab bounces back to the top.
- **Toggle state is no longer visual-only** — WCAG 4.1.2 (Name, Role, Value).
- Landmark structure and heading semantics are also signals search engines use to identify a page's primary content, so this is a small ranking-side win alongside the accessibility one.

## Verification

- `npm ci` → clean
- `npm run build` → passes, all 18 routes prerender
- `npm run lint` → no warnings or errors
- Checked the emitted HTML: `.next/server/app/about-me.html` now contains `id="main-content"` (it had no `<main>` before), the skip link is present on project pages, and `index.html` contains exactly one `<main>` — the section swap in Hero did not leave a nested one.

## Notes

No visible copy changed apart from the skip link's "Skip to content", which is hidden until focused. No new dependencies, no config changes, no TODO placeholders left behind.

---
_Generated by [Claude Code](https://claude.ai/code/session_018mPcZgfCS6ztGcHJ1UoqZ8)_