### PR TITLE
Respect "Reduce motion" instead of ignoring it

### DIFF
--- a/app/components/Marquee.js
+++ b/app/components/Marquee.js
@@ -8,6 +8,11 @@ const items = [
 ];
 
 export default function Marquee() {
+  // The list is rendered twice because the loop translates the track by half
+  // its width: the second copy is what slides in behind the first, so the strip
+  // never shows a gap. It is a rendering trick, not content — hidden from
+  // assistive tech below so a screen reader reads the six items once instead of
+  // announcing the whole list twice over.
   const track = [...items, ...items];
 
   return (
@@ -16,6 +21,7 @@ export default function Marquee() {
         {track.map((item, i) => (
           <span
             key={i}
+            aria-hidden={i >= items.length ? "true" : undefined}
             className="flex items-center font-display italic text-2xl sm:text-3xl px-8 whitespace-nowrap"
           >
             {item}

--- a/app/components/motion/MagneticButton.js
+++ b/app/components/motion/MagneticButton.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef } from "react";
-import { motion, useMotionValue, useSpring } from "framer-motion";
+import { motion, useMotionValue, useReducedMotion, useSpring } from "framer-motion";
 
 // How far the element follows the cursor, as a fraction of the distance from
 // its centre, and the spring that carries it there. Unchanged from the values
@@ -45,6 +45,12 @@ export default function MagneticButton({
 }) {
   const ref = useRef(null);
   const MotionTag = motionTag(Tag);
+  // Same reason as TiltCard: the pull is written to a motion value by hand
+  // rather than animated by Framer, so the global reduced-motion setting does
+  // not reach it and this has to opt out on its own. The button keeps its
+  // colour change on hover, so it still reads as interactive — it just stops
+  // sliding out from under the cursor.
+  const prefersReducedMotion = useReducedMotion();
 
   // Motion values are written to the DOM directly rather than through state, so
   // tracking the cursor no longer re-renders the component ~60 times a second.
@@ -57,7 +63,7 @@ export default function MagneticButton({
 
   function handleMouseMove(e) {
     const el = ref.current;
-    if (!el) return;
+    if (!el || prefersReducedMotion) return;
     const rect = el.getBoundingClientRect();
     targetX.set((e.clientX - rect.left - rect.width / 2) * PULL);
     targetY.set((e.clientY - rect.top - rect.height / 2) * PULL);

--- a/app/components/motion/MotionProvider.js
+++ b/app/components/motion/MotionProvider.js
@@ -1,0 +1,20 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+
+// Almost everything that moves on this site is a Framer Motion animation:
+// headings that slide up as you scroll, cards that tilt under the cursor,
+// buttons that lean towards it, the entry overlay. None of it carried any
+// awareness of "Reduce motion", the OS-level setting a visitor turns on when
+// large moving things make them ill — so the site ignored the one request the
+// platform lets them make.
+//
+// `reducedMotion="user"` reads that setting and drops transform and layout
+// animations for anyone who has it on, site-wide, without every component
+// having to remember. Opacity still animates, which is deliberate: it is the
+// part that does not trigger motion sickness, and keeping it means a
+// `whileInView` reveal still resolves to visible content rather than being
+// skipped into nothing.
+export default function MotionProvider({ children }) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/app/components/motion/TiltCard.js
+++ b/app/components/motion/TiltCard.js
@@ -1,10 +1,22 @@
 "use client";
 
 import { useRef } from "react";
-import { motion, useMotionValue, useSpring, useTransform } from "framer-motion";
+import {
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useSpring,
+  useTransform,
+} from "framer-motion";
 
 export default function TiltCard({ children, className = "" }) {
   const ref = useRef(null);
+  // The tilt is written straight to a motion value from the pointer, which
+  // never goes through Framer's animation path — so MotionConfig's global
+  // reduced-motion handling cannot see it and the card has to check for
+  // itself. Left unchecked, this is a large 3D rotation tracking the cursor,
+  // which is close to the worst case for anyone motion-sensitive.
+  const prefersReducedMotion = useReducedMotion();
   const x = useMotionValue(0);
   const y = useMotionValue(0);
 
@@ -19,7 +31,7 @@ export default function TiltCard({ children, className = "" }) {
 
   function handleMouseMove(e) {
     const el = ref.current;
-    if (!el) return;
+    if (!el || prefersReducedMotion) return;
     const rect = el.getBoundingClientRect();
     x.set((e.clientX - rect.left) / rect.width - 0.5);
     y.set((e.clientY - rect.top) / rect.height - 0.5);

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,12 @@
   --foreground: #171410;
 }
 
-* {
+/* Scrolling is a property of the scrolling container, so this only ever had to
+   be set on the root. Applying it to every element on the page meant the
+   browser carried the property on thousands of nodes that never scroll, and it
+   also caught the ones that do scroll for a reason — the photo strips on the
+   speaking page, the ask panel — animating jumps that should be instant. */
+html {
   scroll-behavior: smooth;
 }
 
@@ -40,5 +45,29 @@ body {
     opacity: 0.04;
     mix-blend-mode: multiply;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  }
+}
+
+/* The CSS half of "Reduce motion". Framer Motion is handled in MotionProvider;
+   these are the animations that run straight from the stylesheet, and they are
+   the ones that never stop on their own: the marquee scrolls the whole width of
+   the viewport forever, and the ping, pulse and blink loops sit in the corner
+   of the eye for as long as the page is open. WCAG asks that moving content
+   which starts by itself and runs past five seconds can be turned off; for a
+   visitor who has said "reduce motion" at the OS level, that is exactly what
+   they have asked for.
+
+   Placed after every @tailwind directive on purpose — these override utility
+   classes of the same specificity, so source order is what decides. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .animate-marquee,
+  .animate-blink,
+  .animate-ping,
+  .animate-pulse {
+    animation: none;
   }
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -4,6 +4,7 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import FloatingControls from "./components/FloatingControls";
 import EntryGate from "./components/EntryGate";
+import MotionProvider from "./components/motion/MotionProvider";
 import { SITE_URL } from "./routes";
 import { SITE_NAME, ogImages, twitterCard } from "./seo";
 import "./globals.css";
@@ -60,32 +61,38 @@ export default function RootLayout({ children }) {
       className={`${geistSans.variable} ${geistMono.variable} ${fraunces.variable}`}
     >
       <body className="grain">
-        <EntryGate />
-        <div className="min-h-screen bg-paper text-ink w-full overflow-x-hidden">
-          {/* Header, footer and the two floating controls sit outside the main
-              landmark on purpose: everything in here is repeated on every
-              route, so a screen reader or keyboard visitor needs a way past it
-              that is not seven Tab presses. The link is invisible until it is
-              focused, at which point it is the first thing in the tab order. */}
-          <a
-            href="#main-content"
-            className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[110] focus:px-5 focus:py-3 focus:rounded-full focus:bg-ink focus:text-paper focus:font-mono focus:text-xs focus:tracking-widest focus:uppercase focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-paper"
-          >
-            Skip to content
-          </a>
-          <Header />
-          {/* The landmark lives here rather than in each page so no route can
-              ship without one — before this only the home page had a <main>,
-              which left every other page with no content landmark at all.
-              tabIndex makes it a valid destination for the skip link: without
-              it the browser moves the viewport but leaves focus behind, and
-              the next Tab returns to the top of the header. */}
-          <main id="main-content" tabIndex={-1} className="focus:outline-none">
-            {children}
-          </main>
-          <Footer />
-          <FloatingControls />
-        </div>
+        {/* Wraps everything, including the header, the footer and the entry
+            overlay, so a visitor with "Reduce motion" turned on gets a still
+            site rather than one where only the page body settled down. */}
+        <MotionProvider>
+          <EntryGate />
+          <div className="min-h-screen bg-paper text-ink w-full overflow-x-hidden">
+            {/* Header, footer and the two floating controls sit outside the
+                main landmark on purpose: everything in here is repeated on
+                every route, so a screen reader or keyboard visitor needs a way
+                past it that is not seven Tab presses. The link is invisible
+                until it is focused, at which point it is the first thing in
+                the tab order. */}
+            <a
+              href="#main-content"
+              className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[110] focus:px-5 focus:py-3 focus:rounded-full focus:bg-ink focus:text-paper focus:font-mono focus:text-xs focus:tracking-widest focus:uppercase focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-paper"
+            >
+              Skip to content
+            </a>
+            <Header />
+            {/* The landmark lives here rather than in each page so no route can
+                ship without one — before this only the home page had a <main>,
+                which left every other page with no content landmark at all.
+                tabIndex makes it a valid destination for the skip link: without
+                it the browser moves the viewport but leaves focus behind, and
+                the next Tab returns to the top of the header. */}
+            <main id="main-content" tabIndex={-1} className="focus:outline-none">
+              {children}
+            </main>
+            <Footer />
+            <FloatingControls />
+          </div>
+        </MotionProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## What changed

The site had no `prefers-reduced-motion` support anywhere. Almost every screen moves — headings slide up on scroll, cards tilt under the cursor, buttons lean toward it, the entry overlay animates in, and the home page runs a marquee that scrolls forever alongside ping/pulse/blink loops that never stop. A visitor who has turned on "Reduce motion" at the OS level got all of it anyway.

Three layers, because the animations come from three different places:

1. **Framer Motion**, handled once at the root — a new `MotionProvider` wraps the tree in `<MotionConfig reducedMotion="user">`, which drops transform and layout animations site-wide for those visitors. Opacity still animates on purpose: it is the part that doesn't cause motion sickness, and keeping it means a `whileInView` reveal still resolves to *visible* content instead of being skipped into nothing.
2. **Hand-written motion values** — `TiltCard` and `MagneticButton` write transforms straight from the pointer rather than animating them, so the global setting can't reach them. Each now checks `useReducedMotion()` itself. Both keep their hover colour change, so they still read as interactive.
3. **CSS animations** — a `@media (prefers-reduced-motion: reduce)` block stops `animate-marquee`, `animate-blink`, `animate-ping` and `animate-pulse`. These are the ones WCAG 2.2.2 is actually about: they start on their own and run well past five seconds with no way to turn them off.

Two smaller things found alongside it:

- `scroll-behavior: smooth` was set on `*` rather than on the root. It only ever applies to scrolling containers, so on every other element it was dead weight — and on the ones that *do* scroll (the photo strips on the speaking page, the ask panel) it animated jumps that should be instant.
- The marquee renders its six items twice so the loop has something to slide in behind itself. The duplicate is a rendering trick, not content, so it's now `aria-hidden`. A screen reader read the whole list twice before.

## Why it helps

Accessibility, primarily: reduced-motion support is the one request the platform lets a motion-sensitive visitor make, and the site was the only party not reading it. It's also a ranking signal — reduced-motion handling and correct `aria-hidden` on decorative duplicates are both things Lighthouse's accessibility audit and Google's page-experience signals look at.

No visible copy changed and nothing moves differently for a visitor who hasn't asked it to.

## Files touched

| File | Change |
| --- | --- |
| `app/components/motion/MotionProvider.js` | New — `MotionConfig reducedMotion="user"` |
| `app/layout.js` | Wraps the tree in `MotionProvider` |
| `app/components/motion/TiltCard.js` | Skips the tilt under reduced motion |
| `app/components/motion/MagneticButton.js` | Skips the magnetic pull under reduced motion |
| `app/globals.css` | Reduced-motion media query; `scroll-behavior` moved off `*` |
| `app/components/Marquee.js` | `aria-hidden` on the duplicated half |

## Build / lint

- `npm ci` — clean
- `npm run build` — passes, 18/18 static pages generated
- `npm run lint` — no warnings or errors
- Verified in the build output that the media query is emitted *after* the Tailwind utilities it overrides (byte 20720 vs 8241), so source order resolves the cascade correctly
- Verified in the served HTML that the first copy of the marquee is announced and the second is hidden

No TODO placeholders left behind. No dependencies added.

## NEEDS APPROVAL: this branch also carries four earlier PRs that never reached `main`

The reduced-motion work above is purely technical and would normally merge itself. This PR should **not** be auto-merged, for a reason that has nothing to do with that change:

`main` is at #11. PRs **#12, #13, #14 and #15** were squash-merged onto this branch rather than into `main`, so their commits ride along in this PR:

- `#12` Fix a dead CTA, 453KB of QR codes, and footer nav reloads
- `#13` Fix stale answers on /ask, plus lost focus and silent state changes
- `#14` Fix MagneticButton swallowing clicks on every CTA
- `#15` Give every page a main landmark and a skip link

That looks like a base-branch mistake in earlier automated runs: those four fixes are real and are currently live nowhere. Landing them is probably what you want, but among them **#12 changes visible copy and a CTA** and **#13 changes `/ask` behaviour** — public-facing changes that are yours to sign off, not mine. Hence approval rather than a merge.

If you would rather land the reduced-motion change on its own, say so and I'll rebase it onto `main` as a single commit and open the other four separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_016HNwokX9hKht3MYT922CjP)_