### PR TITLE
Fix secondary text failing WCAG AA contrast

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,18 @@ module.exports = {
         foreground: "var(--foreground)",
         paper: "#F6F3EC",
         ink: "#171410",
-        muted: "#8A8478",
+        // `muted` is the site's secondary text colour and nothing else — it is
+        // never a background or a border. Almost everywhere it lands on 12px
+        // uppercase mono with wide letter-spacing (dates, locations, stat
+        // labels, section eyebrows, the footer nav), which is the least
+        // forgiving shape small text can take.
+        //
+        // At #8A8478 it measured 3.35:1 against `paper` and 3.12:1 against the
+        // `bg-line/40` stat tiles — short of the 4.5:1 WCAG AA asks of body
+        // text, and short of even the 3:1 allowed for large text on those
+        // tiles. Same hue (40°) and near-identical saturation, darkened until
+        // it clears: 4.99:1 on `paper`, 4.65:1 on `bg-line/40`.
+        muted: "#6E685C",
         line: "#E4DFD2",
         accent: "#FF5A1F",
         accent2: "#5B4CFF",


### PR DESCRIPTION
## What changed

One token in `tailwind.config.js`: `muted` moves from `#8A8478` to `#6E685C`.

`muted` is the site's secondary text colour, and it is *only* a text colour — 44 `text-muted` usages plus 2 `placeholder-muted`, no backgrounds, no borders. So a single token change carries the fix everywhere without touching a component.

## Why it helps

I measured every foreground/background pair the site actually uses. `muted` was the clearest failure:

| Pair | Before | After | WCAG AA needs |
|---|---|---|---|
| `text-muted` on `paper` | **3.35:1** | 4.99:1 | 4.5:1 |
| `text-muted` on `bg-line/40` | **3.12:1** | 4.65:1 | 4.5:1 |

Those are the only two backgrounds `muted` text ever sits on (the `bg-line/40` case is the stat tiles on the Expensorr and Mezohub pages).

What makes this worth fixing rather than shrugging at: almost every one of those 46 usages is 12px uppercase mono with wide letter-spacing — event dates, locations and audience counts on `/public-speaking`, the `// PROFESSIONAL JOURNEY` eyebrows on `/about-me`, stat labels, the footer nav row, the character counter and placeholder in the ask widget. That's the least legible shape small text can take, and it was the text failing contrast. It also sits under the site-wide `.grain` overlay, which takes a little more off.

The new value keeps the palette intact: same hue (40°), near-identical saturation, darkened until it clears. It still reads as a soft warm grey against the paper background rather than a second ink.

Accessibility fixes like this are also a ranking input — contrast is one of the things automated page-quality audits check.

## Files touched

- `tailwind.config.js` — one colour value, plus a comment recording the measured ratios so the next person to reach for a lighter grey can see what it has to clear.

## Build / lint

- `npm ci` ✅
- `npm run build` ✅ (18/18 static pages, bundle sizes unchanged)
- `npm run lint` ✅ no warnings or errors
- Verified in the compiled output: `.text-muted{...color:rgb(110 104 92...)}` — the old value is gone from the CSS entirely.

## Deliberately not fixed here — needs your call, Sarthak

Two contrast failures in the same audit involve the brand orange, so I left them alone rather than change how the site looks on my own judgement:

1. **`text-accent` as text: 2.81:1.** Fails the 4.5:1 for body text and misses even the 3:1 large-text allowance. Affects the conference names on `/public-speaking`, the "View Slides" / "Watch Recording" links, the hero eyebrow, the section headings on the project pages, and the stat figures on `/about-me`.
2. **Primary button hover: 2.81:1.** Every `bg-ink text-paper hover:bg-accent` CTA drops its label to that ratio the moment you hover it.

Both are fixable without abandoning the orange — `#C4400C` measures 4.64:1 and reads as the same colour family, and the button hover could instead flip its label to `text-ink` (5.48:1 on the orange, brand colour untouched). But that is a visible design decision about your brand, so it should be yours. Happy to open it as a follow-up if you want either direction.

No TODO placeholders left behind.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jnj5fcyghFZzocwoNKbdvq)_