### PR TITLE
Give the homepage, about, podcasts and speaking pages real titles

### DIFF
--- a/app/about-me/page.js
+++ b/app/about-me/page.js
@@ -7,8 +7,9 @@ import { canonicalUrl, pageMetadata } from "../seo";
 import { breadcrumbSchema, graph, personSchema } from "../structuredData";
 
 export const metadata = pageMetadata({
-  title: "About Me - Sarthaksavvy",
-  description: "Get to know Sarthak Shrivastava's journey in tech.",
+  title: "About Sarthak Shrivastava — AI Consultant & Docker Captain",
+  description:
+    "The path from software engineer to AI consultant: founding Bitfumes, becoming a Docker Captain, earning AWS certifications, and teaching 100K+ developers.",
   path: "/about-me",
 });
 

--- a/app/page.js
+++ b/app/page.js
@@ -5,8 +5,9 @@ import { pageMetadata } from "./seo";
 import { graph, personSchema, websiteSchema } from "./structuredData";
 
 export const metadata = pageMetadata({
-  title: "Sarthak Shrivastava - Sarthaksavvy",
-  description: "Sarthak Shrivastava's personal website",
+  title: "Sarthak Shrivastava — AI Consultant & Founder of Bitfumes",
+  description:
+    "AI consultant and software engineer helping teams ship LLM features and AI automation. Founder of Bitfumes, Docker Captain, AWS certified, and creator of developer courses watched by 100K+ students.",
   path: "/",
 });
 

--- a/app/podcasts/page.js
+++ b/app/podcasts/page.js
@@ -8,8 +8,9 @@ import { canonicalUrl, ogImages, pageMetadata } from "../seo";
 import { breadcrumbSchema, graph, personSchema } from "../structuredData";
 
 export const metadata = pageMetadata({
-  title: "Sarthak Shrivastava - Podcasts",
-  description: "Podcasts by Sarthak Shrivastava",
+  title: "Laravel India Podcast — Hosted by Sarthak Shrivastava",
+  description:
+    "Conversations with the worldwide Laravel community — including Taylor Otwell, James Brooks and Freek Van der Herten — hosted by AI consultant and Bitfumes founder Sarthak Shrivastava.",
   path: "/podcasts",
   image: ogImages.podcast,
 });

--- a/app/public-speaking/page.js
+++ b/app/public-speaking/page.js
@@ -12,8 +12,9 @@ import {
 } from "../structuredData";
 
 export const metadata = pageMetadata({
-  title: "Sarthak Shrivastava - Public Speaking",
-  description: "Public Speaking by Sarthak Shrivastava",
+  title: "Conference Talks by Sarthak Shrivastava — AI & Laravel",
+  description:
+    "Talks on AI agents, LLM function calling, Laravel and Docker at conferences worldwide, from AI consultant and Docker Captain Sarthak Shrivastava.",
   path: "/public-speaking",
 });
 


### PR DESCRIPTION
## What changed

Four routes were still shipping placeholder-ish `<title>`/meta description pairs left over from before the AI-consulting positioning existed:

| Route | Before | After |
|---|---|---|
| `/` | "Sarthak Shrivastava - Sarthaksavvy" / "Sarthak Shrivastava's personal website" | "Sarthak Shrivastava — AI Consultant & Founder of Bitfumes" / description covering AI automation, Bitfumes, Docker Captain, AWS certs |
| `/about-me` | "About Me - Sarthaksavvy" / "Get to know Sarthak Shrivastava's journey in tech." | "About Sarthak Shrivastava — AI Consultant & Docker Captain" / journey-focused description |
| `/podcasts` | "Sarthak Shrivastava - Podcasts" / "Podcasts by Sarthak Shrivastava" | "Laravel India Podcast — Hosted by Sarthak Shrivastava" / names real guests (Taylor Otwell, James Brooks, Freek Van der Herten) |
| `/public-speaking` | "Sarthak Shrivastava - Public Speaking" / "Public Speaking by Sarthak Shrivastava" | "Conference Talks by Sarthak Shrivastava — AI & Laravel" / reflects the actual talk topics in `events.json` (AI agents, OpenAI function calling, Laravel, Docker) |

## Why it helps

Meanwhile `/ai-consulting` already had a keyword-rich, well-optimized title (`"AI Consultant — LLM Features & Automation | Sarthak Shrivastava"`) built through the same `pageMetadata()` helper. The homepage is the page most likely to be shared or ranked, yet its title/description carried zero signal for the "AI consultant" search intent the rest of the site is built around. This closes that gap using purely the existing metadata plumbing (`app/seo.js`'s `pageMetadata()`), no new mechanism needed.

Every new description is grounded in content that already exists elsewhere on the site — the Hero's "Founder · Builder · AI Consultant" line, the about page's stats/credentials, the podcast's real guest list, and the actual talk titles in `app/events.json` — nothing invented.

## Files touched

- `app/page.js`
- `app/about-me/page.js`
- `app/podcasts/page.js`
- `app/public-speaking/page.js`

## Build/lint status

- `npm ci` — clean
- `npm run build` — passes, all 19 routes generate successfully
- `npm run lint` — no warnings or errors

## TODOs

None left behind by this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hz9M3jBotw6HvN9X3xQg8W)_