### PR TITLE
Add rel=noopener to external target=_blank links missing it

### DIFF
--- a/app/about-me/page.js
+++ b/app/about-me/page.js
@@ -175,6 +175,7 @@ const AboutPage = () => {
               <MagneticButton
                 href="https://youtube.com/bitfumes"
                 target="_blank"
+                rel="noopener noreferrer"
                 className="border border-ink/20 px-6 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:border-ink transition-colors inline-flex"
               >
                 Watch My Content

--- a/app/components/Hero.js
+++ b/app/components/Hero.js
@@ -64,6 +64,7 @@ export default function Hero() {
               <MagneticButton
                 href="https://cal.com/sarthaksavvy"
                 target="_blank"
+                rel="noopener noreferrer"
                 className="bg-ink text-paper px-7 py-4 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent transition-colors flex items-center gap-3 inline-flex"
               >
                 Book a Call

--- a/app/podcasts/page.js
+++ b/app/podcasts/page.js
@@ -102,6 +102,7 @@ export default function Podcasts() {
                       key={p.label}
                       href={p.href}
                       target="_blank"
+                      rel="noopener noreferrer"
                       className="bg-ink text-paper hover:bg-accent transition-colors px-6 py-3 rounded-full font-mono text-xs tracking-widest uppercase inline-flex"
                     >
                       {p.label}

--- a/app/side-projects/mezohub/page.js
+++ b/app/side-projects/mezohub/page.js
@@ -275,6 +275,7 @@ export default function MezohubProject() {
             <a
               href="https://mezohub.com"
               target="_blank"
+              rel="noopener noreferrer"
               className="bg-ink text-paper px-8 py-3 rounded-full font-medium hover:bg-accent transition-colors inline-flex items-center gap-2"
             >
               Visit Platform

--- a/app/side-projects/page.js
+++ b/app/side-projects/page.js
@@ -192,6 +192,7 @@ export default function SideProjects() {
                     <MagneticButton
                       href={project.link}
                       target="_blank"
+                      rel="noopener noreferrer"
                       className="inline-flex items-center gap-2 border border-ink/20 px-6 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:border-ink transition-colors"
                     >
                       Visit Project


### PR DESCRIPTION
## What changed

Five `target="_blank"` links to external sites were missing `rel="noopener noreferrer"`:

- `app/components/Hero.js` — the "Book a Call" button (cal.com)
- `app/about-me/page.js` — the "Watch My Content" button (youtube.com/bitfumes)
- `app/podcasts/page.js` — the Apple Podcasts / Spotify / YouTube platform buttons
- `app/side-projects/page.js` — the "Visit Project" button in the projects grid (per-project external `project.link`)
- `app/side-projects/mezohub/page.js` — the second "Visit Platform" CTA (mezohub.com already had `rel` on its first CTA, not its second)

## Why it helps

A `target="_blank"` link without `rel="noopener"` leaves the opened page holding a `window.opener` reference back to this site, which lets that page navigate/replace the origin tab — the standard "reverse tabnabbing" gap. Every other external link in the repo already carries `rel="noopener noreferrer"` (added across earlier PRs); these five were the remaining gaps in that otherwise-consistent pattern. This is a same-page attribute fix — no visible copy, positioning, or link destinations changed.

## Files touched

- `app/components/Hero.js`
- `app/about-me/page.js`
- `app/podcasts/page.js`
- `app/side-projects/page.js`
- `app/side-projects/mezohub/page.js`

## Build/lint status

- `npm ci` — clean
- `npm run build` — passes (all 19 routes generated)
- `npm run lint` — no warnings or errors

## TODO placeholders

None added.


---
_Generated by [Claude Code](https://claude.ai/code/session_0187D9FnYBHLhwQ1M5AfZ7R7)_