### PR TITLE
Add rel=noopener to the two external nav links in Header.js

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -22,6 +22,7 @@ function NavLink({ href, label, external, pathname, onClick }) {
       href={href}
       onClick={onClick}
       target={external ? "_blank" : undefined}
+      rel={external ? "noopener noreferrer" : undefined}
       className="group relative font-mono text-xs tracking-widest uppercase text-ink/70 hover:text-ink transition-colors"
     >
       {label}
@@ -128,6 +129,7 @@ export default function Header() {
                   <Link
                     href={link.href}
                     target={link.external ? "_blank" : undefined}
+                    rel={link.external ? "noopener noreferrer" : undefined}
                     onClick={() => setIsOpen(false)}
                     className="font-display italic text-2xl"
                   >


### PR DESCRIPTION
## What changed

`app/components/Header.js` renders the site's primary nav (desktop bar and mobile menu) on every route. Two of its links — YouTube and Courses — open with `target="_blank"` but had no `rel="noopener noreferrer"`. Without it, the page that opens keeps a `window.opener` reference back to this site and can navigate it (reverse tabnabbing).

PR #20 fixed this exact issue on five other links across the site (Hero, about-me, podcasts, side-projects, mezohub) but didn't touch `Header.js` — which is the one component that appears on *every* page, so the gap was actually the widest-reaching one left. A repo-wide grep now shows every `target="_blank"` link carries the attribute except these two, which this PR closes.

## Why it helps

Security fix: closes a reverse-tabnabbing gap on the site's most-visited surface (the global nav), consistent with the pattern already established everywhere else in the codebase.

## Files touched

- `app/components/Header.js` — added `rel={external ? "noopener noreferrer" : undefined}` to the desktop `NavLink` and the mobile nav `Link`.

## Build/lint status

- `npm run lint` — passes, no warnings
- `npm run build` — passes, all 19 routes generate successfully

## TODO placeholders

None.

NEEDS APPROVAL: this touches security (reverse-tabnabbing mitigation on outbound links) — flagged per the repo's auto-merge policy rather than merged automatically.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mbx8vYRiERSDbmLngyTRR8)_