### PR TITLE
Add a branded 404 page instead of the default Next.js one

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -1,0 +1,65 @@
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import Reveal from "./components/motion/Reveal";
+import { StaggerGroup, StaggerItem } from "./components/motion/Stagger";
+import MagneticButton from "./components/motion/MagneticButton";
+
+// Without this file, Next.js falls back to its own unstyled "404 | This page
+// could not be found" — no nav context beyond the header/footer the root
+// layout already provides, and no path back in for a broken or typo'd link.
+// This gives a lost visitor the same three or four places everyone else on
+// the site is pointed toward instead of a dead end.
+export const metadata = {
+  title: "Page Not Found — Sarthak Shrivastava",
+  description: "This page doesn't exist or has moved.",
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+const destinations = [
+  { href: "/", label: "Home" },
+  { href: "/ai-consulting", label: "AI Consulting" },
+  { href: "/side-projects", label: "Side Projects" },
+  { href: "/about-me", label: "About Me" },
+];
+
+export default function NotFound() {
+  return (
+    <div className="py-10 px-6 sm:px-10 min-h-[70vh] flex items-center">
+      <div className="max-w-[1400px] mx-auto w-full">
+        <Reveal>
+          <p className="font-mono text-xs sm:text-sm tracking-[0.35em] uppercase text-accent mb-6">
+            404
+          </p>
+          <h1 className="font-display text-6xl sm:text-7xl md:text-8xl leading-[0.95] mb-6">
+            Page not <span className="italic text-accent">found.</span>
+          </h1>
+          <p className="text-lg text-ink/70 mb-12 max-w-lg leading-relaxed">
+            The link is broken, or the page moved. Here&apos;s where everyone
+            else on the site starts.
+          </p>
+        </Reveal>
+
+        <StaggerGroup className="flex flex-wrap items-center gap-4">
+          {destinations.map((destination, i) => (
+            <StaggerItem key={destination.href}>
+              <MagneticButton
+                href={destination.href}
+                className={
+                  i === 0
+                    ? "bg-ink text-paper px-7 py-4 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent transition-colors inline-flex items-center gap-3"
+                    : "border border-ink/25 text-ink px-7 py-4 rounded-full font-mono text-xs tracking-widest uppercase hover:border-ink transition-colors inline-flex items-center gap-3"
+                }
+              >
+                {destination.label}
+                {i === 0 && <ArrowRight size={16} aria-hidden="true" />}
+              </MagneticButton>
+            </StaggerItem>
+          ))}
+        </StaggerGroup>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed

The repo had no `app/not-found.js`. Any broken link, typo'd URL, or stale bookmark (`/side-projects/typo`, an old route, etc.) fell through to Next.js's generic, unstyled `404 | This page could not be found` — no site chrome beyond whatever the root layout still renders, and no way back in except the browser's back button.

This adds `app/not-found.js`: a 404 page in the same "paper" aesthetic as every other route (same heading treatment, same `Reveal` entrance, same button styling), with links to Home, AI Consulting, Side Projects and About Me — the same core destinations the footer already points to.

- `title`/`description` follow the site's existing naming convention.
- `robots: { index: false, follow: true }` — a 404 has nothing worth indexing, but its outbound links should still be crawlable, same reasoning already used on `/ask`.
- No new nav items, no change to `routes.js` or the sitemap.
- Verified the route still returns an actual `404` status (`next start` + `curl -o /dev/null -w "%{http_code}"` → `404`), so this only replaces the *page*, not Next's not-found handling.

## Why it helps

Mostly UX/retention, not a ranking mechanism: a visitor who lands on a dead link now sees a page that looks like the rest of the site and gets three concrete next steps, instead of a dead end that reads as the site being broken. It's also a small crawl-hygiene win — a 404 that correctly returns `404` (already true) and stays out of the index (now explicit) rather than accidentally becoming an indexable soft-404.

## Files touched

- `app/not-found.js` — new file (only change)

## Build / lint status

- `npm ci` — clean
- `npm run lint` — no ESLint warnings or errors
- `npm run build` — passes, 19/19 static pages generate
- Manually verified with `next start`: `/ai-consulting` and other routes render unchanged, an unknown path renders the new page and returns HTTP 404, `/` returns HTTP 200

## TODO placeholders

None.

This is a structural/UX fix with no positioning claims, service descriptions, or new copy about Sarthak — same bucket as prior accessibility/structural fixes (main landmark, duplicate-h1, contrast) — so no new dependencies, no security surface, no deploy-config changes, no public-image copy. Auto-merging per the repo's existing policy for purely technical changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RCNXok6s3PyvYPapSfESSo)_