### PR TITLE
Add baseline security response headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,47 @@
+// Baseline response headers the app never set on its own. None of these
+// depend on how a page is rendered, so applying them to every route is safe:
+// there is no framing, no cross-origin embedding and no use of camera/mic/
+// geolocation anywhere on the site for these to interfere with.
+const securityHeaders = [
+  // Stops a browser from guessing a response's MIME type from its content,
+  // which is how a misconfigured upload or an old browser can be tricked
+  // into executing something served as plain text or an image.
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  // The site is never meant to render inside someone else's <iframe> — this
+  // closes off clickjacking, where a transparent frame of the real page is
+  // laid over a decoy to hijack clicks.
+  { key: "X-Frame-Options", value: "DENY" },
+  // Full referrer only ever goes to the site's own pages; other origins get
+  // just the scheme+host, not the full path (which could leak a query like
+  // an /ask question) or downgrade to plain HTTP.
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // Explicitly denies the sensor/media APIs the site has no use for, so an
+  // injected or compromised third-party script embedded in the future
+  // cannot request them.
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  // Forces HTTPS on repeat visits for a year, so a stale bookmark or typed
+  // "http://" cannot be downgraded to an insecure connection.
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains",
+  },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## What changed

`next.config.mjs` set no security response headers at all — no `X-Frame-Options`, no `X-Content-Type-Options`, no `Referrer-Policy`, no `Permissions-Policy`, no `Strict-Transport-Security`. Every route (pages and the `/api/ask` route) was serving with only Next.js's defaults.

Added a `headers()` function in `next.config.mjs` that applies to every route (`/:path*`):

- `X-Content-Type-Options: nosniff` — stops MIME-sniffing of responses.
- `X-Frame-Options: DENY` — the site is never meant to be framed by another origin; this closes off clickjacking.
- `Referrer-Policy: strict-origin-when-cross-origin` — cross-origin requests get scheme+host only, not a full path (relevant since `/ask` puts the question in the URL as `?q=`).
- `Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()` — the site uses none of these APIs; explicitly denying them closes the door on a future compromised or injected third-party script requesting them.
- `Strict-Transport-Security: max-age=31536000; includeSubDomains` — forces HTTPS on repeat visits for a year.

**Deliberately not included:** a Content-Security-Policy. The site renders inline `<script type="application/ld+json">` blocks (`app/components/JsonLd.js`) and uses framer-motion / three.js / WebGL, which commonly need `unsafe-inline` / `unsafe-eval` or a nonce-based setup to keep working. Getting that right needs careful, dedicated testing rather than a header added alongside four safe ones — left out of scope for this PR rather than risking a broken site.

## Why it helps

Directly addresses part (c) of this routine's brief — a real, previously-unfixed security gap, not a cosmetic one. These are the same baseline headers most hardening checklists (OWASP secure headers project, Mozilla Observatory) flag first, and none of the 22 previously-merged PRs from this routine touched `next.config.mjs` or response headers.

## Files touched

- `next.config.mjs` — added `headers()` with the five headers above (only change)

## Build / lint status

- `npm ci` — clean
- `npm run build` — passes, 19/19 static pages generate
- `npm run lint` — no ESLint warnings or errors
- Manually verified with `next start`: `curl -D -` against `/` and `/about-me` both return all five headers on every response

## TODO placeholders

None.

---

NEEDS APPROVAL: this touches response headers, which the routine's rules treat as security-surface — opening for Sarthak's review rather than auto-merging, even though the change is additive and was verified live against a running server.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133AXE5F9thTRzvvjbz7kCx)_