### PR TITLE
Fix stale sarthak@bitfumes.com contact links across the site

### DIFF
--- a/app/about-me/page.js
+++ b/app/about-me/page.js
@@ -167,7 +167,7 @@ const AboutPage = () => {
             </p>
             <div className="flex flex-wrap gap-4">
               <MagneticButton
-                href="mailto:sarthak@bitfumes.com"
+                href="mailto:hello@sarthaksavvy.com"
                 className="bg-ink text-paper px-6 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent transition-colors inline-flex"
               >
                 Get in Touch

--- a/app/api/ask/route.js
+++ b/app/api/ask/route.js
@@ -96,8 +96,8 @@ Contact:
 - Website: https://sarthaksavvy.com
 - LinkedIn: https://linkedin.com/in/sarthaksavvy
 - YouTube: https://youtube.com/bitfumes
-- Email: sarthak@bitfumes.com
-- Courses: https://bitfumes.com
+- Email: hello@sarthaksavvy.com
+- Courses: https://courses.sarthaksavvy.com/
 
 Side Projects:
 - Mezohub: A centralized platform for connecting developers, designers, and entrepreneurs

--- a/app/public-speaking/page.js
+++ b/app/public-speaking/page.js
@@ -60,7 +60,7 @@ export default function SpeakingTimeline() {
             I&apos;m available for conferences, meetups, and workshops worldwide.
           </p>
           <MagneticButton
-            href="mailto:sarthak@bitfumes.com"
+            href="mailto:hello@sarthaksavvy.com"
             className="bg-ink text-paper px-8 py-4 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent transition-colors inline-flex items-center gap-2"
           >
             Get in Touch

--- a/app/side-projects/page.js
+++ b/app/side-projects/page.js
@@ -214,7 +214,7 @@ export default function SideProjects() {
             projects. Let&apos;s create something amazing together!
           </p>
           <MagneticButton
-            href="mailto:sarthak@bitfumes.com"
+            href="mailto:hello@sarthaksavvy.com"
             className="bg-ink text-paper px-8 py-4 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent transition-colors inline-flex items-center gap-2"
           >
             Get in Touch


### PR DESCRIPTION
## What changed

Four "get in touch" contact points on the site were pointing at `sarthak@bitfumes.com`, while every other contact point — the footer (shown on every page), the AI-consulting page copy, and the `Person` JSON-LD structured data — advertises `hello@sarthaksavvy.com` as the real address:

- `app/about-me/page.js` — "Get in Touch" CTA
- `app/public-speaking/page.js` — "Get in Touch" CTA (speaking inquiries)
- `app/side-projects/page.js` — "Get in Touch" CTA (collaboration inquiries)
- `app/api/ask/route.js` — the `/ask` chatbot's `FALLBACK_CONTENT`, which the AI assistant serves to visitors when it can't crawl the live site. Also fixed the neighboring stale "Courses: https://bitfumes.com" line in the same block to `https://courses.sarthaksavvy.com/`, matching the actual nav link in `Header.js`.

## Why this matters

This is a plain correctness bug, not a style choice: three separate CTAs across the site were silently routing visitor emails to a different address than the one prominently displayed in the footer of every single page and in the site's own structured data. A visitor (or a search engine reading the `Person` schema) would reasonably assume `hello@sarthaksavvy.com` is correct, since that's what's stated everywhere else — the stray `sarthak@bitfumes.com` links looked like leftovers from before the site was rebranded onto the `sarthaksavvy.com` domain. Fixing it means every contact path on the site now agrees, and the AI chatbot's fallback answer no longer hands out a stale email/courses link when the live crawl fails.

## Files touched

- `app/about-me/page.js`
- `app/public-speaking/page.js`
- `app/side-projects/page.js`
- `app/api/ask/route.js`

## Build/lint status

- `npm run build` — passed
- `npm run lint` — passed, no warnings

No TODO placeholders were added.

**NEEDS APPROVAL:** this PR changes a contact detail (email address) shown to visitors across multiple pages — that falls under "personal information about Sarthak" / "public image" per this routine's rules, so it is left open for Sarthak to review and merge rather than auto-merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_017FNM1spipAUQm52PvH39Gt)_