### PR TITLE
Fix copy-pasted placeholder text on the Mezohub project page

### DIFF
--- a/app/side-projects/mezohub/page.js
+++ b/app/side-projects/mezohub/page.js
@@ -2,9 +2,9 @@ import {
   ArrowLeft,
   ArrowRight,
   CheckCircle,
-  Code,
   ExternalLink,
   MessageCircle,
+  Search,
   Share2,
   Users,
 } from "lucide-react";
@@ -21,10 +21,10 @@ import {
 const SITE = "https://mezohub.com";
 
 const DESCRIPTION =
-  "Mezohub is a platform for developers, freelancers, and entrepreneurs to deploy your backend project with ease.";
+  "Mezohub is a centralized platform for connecting developers, designers, and entrepreneurs to collaborate on innovative projects.";
 
 export const metadata = pageMetadata({
-  title: "Mezohub - Backend Deployment Platform | Sarthak Shrivastava",
+  title: "Mezohub - Collaboration Platform | Sarthak Shrivastava",
   description: DESCRIPTION,
   path: "/side-projects/mezohub",
   image: ogImages.mezohub,
@@ -49,28 +49,28 @@ const structuredData = graph(
 export default function MezohubProject() {
   const features = [
     {
-      icon: <Users size={24} className="text-accent" />,
-      title: "Team Formation",
+      icon: <Search size={24} className="text-accent" />,
+      title: "Project Discovery",
       description:
-        "Deploy your backend project with ease. Our intelligent matching algorithm connects you with the right people.",
+        "Browse projects looking for collaborators, and get matched with the ones that fit your skills and interests.",
     },
     {
-      icon: <Share2 size={24} className="text-accent" />,
-      title: "Project Showcase",
+      icon: <Users size={24} className="text-accent" />,
+      title: "Skill-Based Team Formation",
       description:
-        "Deploy your backend project with ease. Our intelligent matching algorithm connects you with the right people.",
+        "Build a team around the skills a project actually needs, connecting developers, designers, and entrepreneurs.",
     },
     {
       icon: <MessageCircle size={24} className="text-accent" />,
       title: "Integrated Messaging",
       description:
-        "Deploy your backend project with ease. Our intelligent matching algorithm connects you with the right people.",
+        "Message collaborators directly inside Mezohub, so coordinating a team doesn't mean jumping to another app.",
     },
     {
-      icon: <Code size={24} className="text-accent" />,
-      title: "Resource Sharing",
+      icon: <Share2 size={24} className="text-accent" />,
+      title: "Project Showcase",
       description:
-        "Deploy your backend project with ease. Our intelligent matching algorithm connects you with the right people.",
+        "Showcase finished and in-progress work in a public portfolio, so it's discoverable by the wider community.",
     },
   ];
 
@@ -78,28 +78,28 @@ export default function MezohubProject() {
     {
       title: "For Developers",
       points: [
-        "Deploy your backend project with ease",
-        "Showcase your coding skills and portfolio",
-        "Connect with designers and other professionals",
-        "Learn new technologies through collaboration",
+        "Discover projects that match your skills",
+        "Get matched onto teams through skill-based team formation",
+        "Coordinate with teammates via integrated messaging",
+        "Showcase what you've built in a public portfolio",
       ],
     },
     {
       title: "For Designers",
       points: [
-        "Deploy your backend project with ease",
-        "Showcase your coding skills and portfolio",
-        "Connect with designers and other professionals",
-        "Learn new technologies through collaboration",
+        "Find projects that need design collaborators",
+        "Join teams through skill-based matching",
+        "Stay in sync with the team via integrated messaging",
+        "Build a portfolio of the projects you've shipped",
       ],
     },
     {
       title: "For Entrepreneurs",
       points: [
-        "Deploy your backend project with ease",
-        "Showcase your coding skills and portfolio",
-        "Connect with designers and other professionals",
-        "Learn new technologies through collaboration",
+        "Discover developers and designers for your idea",
+        "Form a team through skill-based matching",
+        "Keep the team aligned with integrated messaging",
+        "Showcase your project to attract collaborators",
       ],
     },
   ];
@@ -125,7 +125,7 @@ export default function MezohubProject() {
             <h1 className="font-display text-5xl md:text-6xl mb-6">Mezohub</h1>
             <p className="text-xl text-ink/70 mb-8">
               A platform for connecting developers, designers, and entrepreneurs
-              to deploy their backend project with ease. Mezohub bridges the gap
+              to collaborate on innovative projects. Mezohub bridges the gap
               between ideas and execution.
             </p>
             <div className="flex flex-wrap gap-4">
@@ -158,15 +158,16 @@ export default function MezohubProject() {
           </h2>
           <div className="bg-paper border border-line rounded-3xl p-8 shadow-lg">
             <p className="text-ink/70 mb-6">
-              Mezohub was born out of the need to deploy your backend project
-              with ease. The platform solves the common problem of deployment
-              and deployment of backend projects.
+              Mezohub solves a different problem than most project tools:
+              finding the right people to build with. It&apos;s a dedicated
+              space where developers, designers, and entrepreneurs can
+              discover projects and each other.
             </p>
             <p className="text-ink/70">
-              As a developer, I often found it challenging to deploy my backend
-              project with ease. Mezohub addresses this by creating a dedicated
-              space where skills, projects, and ideas can converge, making the
-              collaboration process more efficient and productive.
+              Project discovery, skill-based team formation, integrated
+              messaging, and portfolio showcases live in one place, so
+              collaboration doesn&apos;t mean stitching together five
+              separate tools.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## What changed

`app/side-projects/mezohub/page.js` had leftover placeholder copy that was never customized per-section:

- All four **Key Features** cards ("Team Formation", "Project Showcase", "Integrated Messaging", "Resource Sharing") shared the exact same description: *"Deploy your backend project with ease. Our intelligent matching algorithm connects you with the right people."*
- All three **Who Benefits** columns ("For Developers", "For Designers", "For Entrepreneurs") repeated the identical four bullet points verbatim — so "For Designers" told designers to "connect with designers," and "For Entrepreneurs" told entrepreneurs to "showcase your coding skills."
- The page's own `title`/`description` metadata (and therefore its JSON-LD `SoftwareApplication` schema) called Mezohub a **"Backend Deployment Platform"**, contradicting how the site's own `/side-projects` index already correctly describes it: *"A centralized platform for connecting developers, designers, and entrepreneurs to collaborate on innovative projects."*
- The "Project Overview" section repeated the same wrong "deploy your backend project" framing, including a first-person claim that doesn't match the product.

I rewrote the feature cards, benefits columns, overview copy, hero paragraph, and metadata to describe what Mezohub actually is, sourcing every fact from the site's own `/side-projects` index page (project discovery, skill-based team formation, integrated messaging, project showcase) rather than inventing anything new. No new claims, metrics, or testimonials were added — this is strictly a correction using facts already stated elsewhere on the site.

Renamed the fourth feature card from "Resource Sharing" (not a real Mezohub feature per the index page) to "Project Discovery," matching the index's actual feature list, and swapped its icon from `Code` to `Search` accordingly.

## Why it helps

- **Bug fix**: visibly broken/duplicate content on a live page a visitor or recruiter is meant to read as a serious showcase of Sarthak's work.
- **SEO**: the page's own meta description and JSON-LD `description` were factually wrong and inconsistent with the rest of the site — search engines and crawlers were indexing an incorrect description of the product.

## Files touched

- `app/side-projects/mezohub/page.js`

## Build/lint status

- `npm run lint` — passes (no warnings or errors)
- `npm run build` — passes (all 19 routes generate successfully)

## TODOs left behind

None. No new placeholders were introduced.

---

**NEEDS APPROVAL:** This PR changes visible copy describing one of Sarthak's own projects (Mezohub) — positioning/product description language that a visitor reads as a statement from Sarthak. Per the routine's rules, changes to public-image copy require Sarthak's review before merging, so this is left open rather than auto-merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XP2koWvG4ZHKZTaR2RAQcV)_