### PR TITLE
Fix stale public-speaking hero copy that describes the wrong talks

### DIFF
--- a/app/public-speaking/page.js
+++ b/app/public-speaking/page.js
@@ -36,8 +36,8 @@ export default function SpeakingTimeline() {
           </Reveal>
           <Reveal delay={0.1} className="md:col-span-4 flex items-end">
             <p className="text-lg text-ink/70">
-              Sharing knowledge at tech conferences worldwide — frontend
-              development, accessibility, and modern web technologies.
+              Sharing knowledge at tech conferences worldwide — AI agents,
+              LLM applications, and Laravel in production.
             </p>
           </Reveal>
         </div>


### PR DESCRIPTION
## What changed

The `/public-speaking` hero subhead (`app/public-speaking/page.js`) said:

> "Sharing knowledge at tech conferences worldwide — frontend development, accessibility, and modern web technologies."

That doesn't match anything on the page. I checked all 6 talks in `app/events.json` and none are about frontend/accessibility — they're "Function calling in OpenAI," "Deploy Laravel with Docker," "AI MASTERCLASS 2025: From Roadmap to Real-World Agents," "Content Creation with AI," "Vibe Coding with Laravel," and a general talk on learning skills. It also contradicts the page's own metadata one function call above it, which already correctly says: *"Talks on AI agents, LLM function calling, Laravel and Docker at conferences worldwide."*

This looks like leftover copy from before the site repositioned around AI consulting. I updated the subhead to:

> "Sharing knowledge at tech conferences worldwide — AI agents, LLM applications, and Laravel in production."

which matches the actual talk list and the page's metadata.

## Why it helps

- **Bug fix**: visible copy contradicted the real content on the same page — a visitor scanning the hero would expect frontend/a11y talks and find AI/Laravel talks instead.
- **SEO**: the page was sending mixed topical signals (hero copy says one thing, metadata + structured data say another). Aligning them reinforces the AI-consultant/LLM search intent this page's metadata already targets.

## Files touched

- `app/public-speaking/page.js` (2-line copy change)

## Build/lint status

- `npm run lint` — passes, no warnings
- `npm run build` — passes, all 20 routes generate successfully

## TODOs left behind

None.

---

**NEEDS APPROVAL:** this PR changes visible copy that a visitor reads as a description of Sarthak's own speaking topics/positioning. Per this routine's rules, changes to public-facing copy require Sarthak's review before merging, so this is left open rather than auto-merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqrHNtXvi1jUPURFx3essb)_