### PR TITLE
Trap focus inside the floating ask panel

### DIFF
--- a/app/components/FloatingChatWidget.js
+++ b/app/components/FloatingChatWidget.js
@@ -3,6 +3,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
+const FOCUSABLE =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
 // Open state is owned by FloatingControls so the reset button can move out of
 // the way while the panel is expanded. Positioning lives there too — this
 // component only draws the launcher and the panel.
@@ -15,6 +18,7 @@ export default function FloatingChatWidget({
   const router = useRouter();
   const launcherRef = useRef(null);
   const inputRef = useRef(null);
+  const panelRef = useRef(null);
   // The launcher unmounts while the panel is open, so its ref is null exactly
   // when we want to focus it. Instead we note that focus is owed and hand it
   // back on the render where the launcher exists again.
@@ -36,7 +40,11 @@ export default function FloatingChatWidget({
 
   // A panel that covers part of the page needs a way out that is not a mouse
   // aimed at a 12px glyph: Escape closes it, and focus lands in the textarea
-  // on open rather than staying behind on the page underneath.
+  // on open rather than staying behind on the page underneath. Tab is also
+  // trapped inside it — the launcher gets its focus back on close (above),
+  // so a keyboard visitor who tabs off the end of the panel while it is open
+  // should stay inside it rather than landing somewhere in the page behind,
+  // same as the entry gate overlay does.
   useEffect(() => {
     if (!open) {
       if (focusOwedRef.current) {
@@ -52,6 +60,26 @@ export default function FloatingChatWidget({
       if (event.key === "Escape") {
         event.preventDefault();
         close();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const panel = panelRef.current;
+      const items = panel ? Array.from(panel.querySelectorAll(FOCUSABLE)) : [];
+      if (!items.length) return;
+
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      const outside = !panel.contains(active);
+
+      if (event.shiftKey && (outside || active === first)) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (outside || active === last)) {
+        event.preventDefault();
+        first.focus();
       }
     }
 
@@ -62,7 +90,9 @@ export default function FloatingChatWidget({
   if (open) {
     return (
       <div
+        ref={panelRef}
         role="dialog"
+        aria-modal="true"
         aria-labelledby="ask-widget-title"
         className={`pointer-events-auto bg-paper border border-line rounded-2xl p-6 w-full max-w-[20rem] shadow-2xl ${className}`}
       >


### PR DESCRIPTION
## What changed
`app/components/FloatingChatWidget.js` — the floating "Ask anything about Sarthak" panel now traps Tab focus inside itself while open, and sets `aria-modal="true"` on its `role="dialog"` container.

## Why
The panel already behaved like a modal in every other respect: it moves focus into the textarea on open, restores focus to the launcher button on close, and closes on Escape. But Tab was never trapped, so a keyboard user could tab straight out of the still-open panel into whatever came next in the page's DOM order — leaving the panel visually open but no longer reachable from where focus landed. `EntryGate.js` already solves this exact problem for the site's other overlay (with the same reasoning documented in its own comments); this brings the ask panel in line with that existing, working pattern instead of introducing a new one. `aria-modal="true"` makes the ARIA role match the actual (now-trapped) behavior for assistive tech.

## Files touched
- `app/components/FloatingChatWidget.js`

## Verification
- `npm run lint` — clean, no warnings or errors.
- `npm run build` — succeeds, all routes prerender as before, bundle sizes unchanged.
- Manually traced the Tab/Shift+Tab cycle: close button → textarea → Ask button → wraps back to close button, matching `EntryGate`'s trap logic.

No copy, layout, or visible content changed — purely a keyboard-accessibility fix. No TODO placeholders introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgW49dVP7zhdfeT1KnDoBN)_