### PR TITLE
Remove fabricated user testimonials from Ginger and Expensorr pages

### DIFF
--- a/app/side-projects/expensorr/page.js
+++ b/app/side-projects/expensorr/page.js
@@ -6,7 +6,6 @@ import {
   PieChart,
   Scan,
   Smartphone,
-  Star,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -76,24 +75,6 @@ export default function ExpensorrProject() {
       title: "Multi-currency Support",
       description:
         "Track expenses in different currencies, perfect for travelers or those who manage finances across multiple countries.",
-    },
-  ];
-
-  const testimonials = [
-    {
-      text: "This app has completely changed how I manage my finances. The receipt scanning feature is a game-changer!",
-      author: "John D.",
-      rating: 5,
-    },
-    {
-      text: "I've tried many expense trackers, but Expensorr stands out with its intuitive interface and powerful analytics.",
-      author: "Sarah M.",
-      rating: 5,
-    },
-    {
-      text: "The multi-currency support is perfect for my business trips. Highly recommended for frequent travelers.",
-      author: "Michael T.",
-      rating: 4,
     },
   ];
 
@@ -272,39 +253,6 @@ export default function ExpensorrProject() {
             </div>
           </div>
         </div> */}
-
-        {/* Testimonials */}
-        <div className="mb-20">
-          <h2 className="font-display italic text-3xl mb-8 text-accent">
-            User Testimonials
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {testimonials.map((testimonial, index) => (
-              <div
-                key={index}
-                className="bg-paper border border-line rounded-3xl p-8 shadow-lg"
-              >
-                <div className="flex mb-4">
-                  {[...Array(5)].map((_, i) => (
-                    <Star
-                      key={i}
-                      size={20}
-                      className={
-                        i < testimonial.rating
-                          ? "text-accent fill-[#FF5A1F]"
-                          : "text-muted"
-                      }
-                    />
-                  ))}
-                </div>
-                <p className="text-ink/70 mb-6">
-                  &quot;{testimonial.text}&quot;
-                </p>
-                <p className="font-semibold">{testimonial.author}</p>
-              </div>
-            ))}
-          </div>
-        </div>
 
         {/* Technologies Used */}
         <div className="mb-20">

--- a/app/side-projects/ginger/page.js
+++ b/app/side-projects/ginger/page.js
@@ -6,7 +6,6 @@ import {
   MessageSquare,
   RefreshCw,
   Shield,
-  Star,
   Zap,
 } from "lucide-react";
 import Link from "next/link";
@@ -72,24 +71,6 @@ export default function GingerProject() {
       title: "Generous Free Usage",
       description:
         "Enjoy 100 free comment generations as a guest user. Sign in to unlock 300 generations for even more networking opportunities.",
-    },
-  ];
-
-  const testimonials = [
-    {
-      text: "Ginger has transformed how I engage on LinkedIn. The comments it generates are indistinguishable from what I would write myself!",
-      author: "Emma R.",
-      rating: 5,
-    },
-    {
-      text: "This extension has saved me countless hours while helping me maintain an active presence on LinkedIn. A must-have for professionals.",
-      author: "David K.",
-      rating: 5,
-    },
-    {
-      text: "The ability to reply to comments with AI assistance has significantly increased my engagement rates. Highly recommended.",
-      author: "Alex M.",
-      rating: 4,
     },
   ];
 
@@ -253,40 +234,6 @@ export default function GingerProject() {
                 </p>
               </div>
             </div>
-          </div>
-        </div>
-
-        {/* Testimonials */}
-        <div className="mb-20">
-          <h2 className="font-display italic text-3xl mb-8 text-accent">
-            User Testimonials
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            {testimonials.map((testimonial, index) => (
-              <div
-                key={index}
-                className="bg-paper border border-line rounded-3xl p-8 shadow-lg"
-              >
-                <div className="flex mb-4">
-                  {[...Array(5)].map((_, i) => (
-                    <Star
-                      key={i}
-                      size={20}
-                      fill={i < testimonial.rating ? "#FF5A1F" : "none"}
-                      className={
-                        i < testimonial.rating
-                          ? "text-accent"
-                          : "text-muted"
-                      }
-                    />
-                  ))}
-                </div>
-                <p className="text-ink/70 mb-6 italic">
-                  &quot;{testimonial.text}&quot;
-                </p>
-                <p className="font-medium">- {testimonial.author}</p>
-              </div>
-            ))}
           </div>
         </div>
 


### PR DESCRIPTION
**NEEDS APPROVAL:** this touches public image / brand — it removes visible copy (testimonials attributed to named people) that a reader takes as a statement from Sarthak about his products' reception.

## What changed

`app/side-projects/ginger/page.js` and `app/side-projects/expensorr/page.js` each had a "User Testimonials" section with three quotes, star ratings, and invented author names (Emma R., David K., Alex M. on Ginger; John D., Sarah M., Michael T. on Expensorr). These are not real reviews — no such users, quotes, or ratings exist anywhere else on the site or in any linked store listing. This PR deletes both `testimonials` sections (data array + rendered markup) and the now-unused `Star` import from each file.

## Why it helps

This is a content-integrity fix, not cosmetic churn. Fabricated reviews presented as genuine:
- misrepresent real user reception of the products under Sarthak's name,
- run against the site's own stated practice elsewhere (the `/ai-consulting` and other project pages are explicit about tracing every claim to something real and never inventing metrics or testimonials — these two sections were inconsistent leftovers, not intentional site voice), and
- carry reputational and endorsement-disclosure risk if a visitor recognizes the reviews as invented.

No real replacement content was substituted — the sections are removed outright rather than filled with more invented text. If real App Store / Chrome Web Store reviews exist that Sarthak wants quoted, those can be added later with proper attribution.

## Files touched

- `app/side-projects/ginger/page.js`
- `app/side-projects/expensorr/page.js`

## Build/lint status

- `npm ci` — clean
- `npm run build` — passes, all 20 routes generate successfully
- `npm run lint` — no ESLint warnings or errors

## TODO placeholders

None left behind — the sections were deleted rather than stubbed, since there was no real content to scaffold toward.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMoNXhiktY1JvGqv4qMHA5)_