### PR TITLE
Fix heading hierarchy skipping h2 on public-speaking and side-projects

### DIFF
--- a/app/components/PublicSpeaking/SingleEvent.js
+++ b/app/components/PublicSpeaking/SingleEvent.js
@@ -22,7 +22,7 @@ export default function SingleEvent({ event, index = 0 }) {
         <div className="p-6">
           <div className="flex justify-between items-start mb-4">
             <div>
-              <h3 className="font-display italic text-2xl mb-2">{event.title}</h3>
+              <h2 className="font-display italic text-2xl mb-2">{event.title}</h2>
               <p className="text-accent font-medium mb-2">{event.conference}</p>
             </div>
           </div>

--- a/app/public-speaking/page.js
+++ b/app/public-speaking/page.js
@@ -53,9 +53,9 @@ export default function SpeakingTimeline() {
         </div>
 
         <Reveal className="mt-24 text-center">
-          <h3 className="font-display italic text-3xl sm:text-4xl mb-4">
+          <h2 className="font-display italic text-3xl sm:text-4xl mb-4">
             Want me to speak at your event?
-          </h3>
+          </h2>
           <p className="text-ink/70 mb-8">
             I&apos;m available for conferences, meetups, and workshops worldwide.
           </p>

--- a/app/side-projects/page.js
+++ b/app/side-projects/page.js
@@ -206,9 +206,9 @@ export default function SideProjects() {
         </StaggerGroup>
 
         <Reveal className="border border-line rounded-3xl p-10 sm:p-14 text-center">
-          <h3 className="font-display italic text-3xl sm:text-4xl mb-4">
+          <h2 className="font-display italic text-3xl sm:text-4xl mb-4">
             Interested in collaborating?
-          </h3>
+          </h2>
           <p className="text-ink/70 mb-8 max-w-2xl mx-auto">
             I&apos;m always open to new ideas and collaborations on interesting
             projects. Let&apos;s create something amazing together!


### PR DESCRIPTION
## What changed

Two content pages skipped a heading level — going straight from the page `<h1>` to `<h3>`s with no `<h2>` in between:

- `app/public-speaking/page.js` — each talk's title (rendered in `app/components/PublicSpeaking/SingleEvent.js`) was an `<h3>`, and the closing "Want me to speak at your event?" CTA was also an `<h3>`.
- `app/side-projects/page.js` — the closing "Interested in collaborating?" CTA was an `<h3>`.

All three are now `<h2>`, matching the pattern the codebase already uses elsewhere — the project card titles on `/side-projects` are correctly `<h2>`, and `app/ask/page.js` has an explicit comment explaining why a "Popular Questions" heading was moved from `<h3>` to `<h2>` for the same reason. These were the two leftover instances of that same bug.

## Why it helps

- **Accessibility (WCAG 1.3.1, Info and Relationships):** screen reader users navigate by heading level to build a document outline. Skipping from h1 straight to h3 hides a level of structure and makes the outline misleading.
- **SEO:** heading hierarchy is one of the signals Google's content-understanding uses to figure out how a page's sections relate to each other. A page with a broken outline gives that signal away for nothing.

No visible copy changed — this is purely a semantic tag swap (`h3` → `h2`). The visual size on all three elements is controlled entirely by the Tailwind classes already on the element, not by browser heading defaults, so nothing renders differently.

## Files touched

- `app/components/PublicSpeaking/SingleEvent.js`
- `app/public-speaking/page.js`
- `app/side-projects/page.js`

## Build/lint status

- `npm ci` — clean
- `npm run build` — passes, all 20 routes generate successfully
- `npm run lint` — no ESLint warnings or errors

## TODO placeholders

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8KLaE6PtfkqJD5H5dB9aL)_