### PR TITLE
Tighten meta descriptions for search snippets

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -7,7 +7,7 @@ import { graph, personSchema, websiteSchema } from "./structuredData";
 export const metadata = pageMetadata({
   title: "Sarthak Shrivastava — AI Consultant & Founder of Bitfumes",
   description:
-    "AI consultant and software engineer helping teams ship LLM features and AI automation. Founder of Bitfumes, Docker Captain, AWS certified, and creator of developer courses watched by 100K+ students.",
+    "AI consultant helping teams ship LLM features and AI automation. Founder of Bitfumes, Docker Captain, AWS certified, and teacher of 100K+ students.",
   path: "/",
 });
 

--- a/app/podcasts/page.js
+++ b/app/podcasts/page.js
@@ -10,7 +10,7 @@ import { breadcrumbSchema, graph, personSchema } from "../structuredData";
 export const metadata = pageMetadata({
   title: "Laravel India Podcast — Hosted by Sarthak Shrivastava",
   description:
-    "Conversations with the worldwide Laravel community — including Taylor Otwell, James Brooks and Freek Van der Herten — hosted by AI consultant and Bitfumes founder Sarthak Shrivastava.",
+    "Conversations with the Laravel community — including Taylor Otwell, James Brooks and Freek Van der Herten — hosted by AI consultant Sarthak Shrivastava.",
   path: "/podcasts",
   image: ogImages.podcast,
 });

--- a/app/side-projects/page.js
+++ b/app/side-projects/page.js
@@ -11,7 +11,8 @@ import { breadcrumbSchema, graph } from "../structuredData";
 
 export const metadata = pageMetadata({
   title: "Sarthak Shrivastava - Side Projects",
-  description: "Side Projects by Sarthak Shrivastava",
+  description:
+    "AI apps built by AI consultant Sarthak Shrivastava — an AI voice-to-text tool, a Premiere Pro AI extension, an expense tracker and a LinkedIn AI assistant.",
   path: "/side-projects",
 });
 


### PR DESCRIPTION
## What changed

- `app/page.js` (homepage): meta description trimmed from 198 to 147 characters.
- `app/podcasts/page.js`: meta description trimmed from 183 to 152 characters.
- `app/side-projects/page.js`: replaced the bare placeholder description ("Side Projects by Sarthak Shrivastava", 37 characters) with a real, keyword-specific one naming the actual AI apps on the page (AudioBolo, Backstage Cut, Expensorr, Ginger).

## Why it helps

Google typically truncates search-result snippets around ~155-160 characters. The homepage and podcasts descriptions ran well past that (198 and 183 chars), so their snippets were being cut off mid-sentence in search results — the AI-consultant positioning at the end of the homepage description ("Docker Captain, AWS certified, and creator of developer courses watched by 100K+ students") was exactly the part most likely to get clipped.

`/side-projects` had a generic four-word description while every other route on the site (about-me, ai-consulting, podcasts, public-speaking, each project page) has a real, descriptive one — this was the one weak leftover.

All three still lead with "AI consultant" / "AI apps" framing, consistent with the site's existing SEO intent around AI-consulting search terms.

No visible page copy changed — only `<meta name="description">` content, which is search-snippet plumbing rather than something a visitor reads on the page.

## Files touched

- `app/page.js`
- `app/podcasts/page.js`
- `app/side-projects/page.js`

## Build/lint status

- `npm ci` — clean
- `npm run build` — passes, all 20 routes generate successfully
- `npm run lint` — no ESLint warnings or errors

## TODO placeholders

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH92szqJBQcMzcR3iyArYb)_