### PR TITLE
Add fetch timeout to YouTube subscriber count lookup

### DIFF
--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -1,5 +1,6 @@
 const CHANNEL_URL = "https://www.youtube.com/@sarthaksavvy";
 const FALLBACK_SUBSCRIBERS = "156K+";
+const FETCH_TIMEOUT_MS = 8000;
 
 function formatSubscribers(rawText) {
   // rawText looks like "134K subscribers" or "1.2M subscribers"
@@ -13,6 +14,7 @@ export async function getSubscriberCount() {
     const res = await fetch(CHANNEL_URL, {
       headers: { "Accept-Language": "en-US,en;q=0.9" },
       next: { revalidate: 86400 },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) {
       console.warn(


### PR DESCRIPTION
## What changed

`getSubscriberCount()` in `lib/youtube.js` fetches the YouTube channel page to scrape a live subscriber count. It was the only outbound network call in the codebase with no timeout — every other one already has this pattern: the page-scrape calls in `app/api/ask/route.js` use `axios` with an 8s timeout, and the LLM call there uses a 35s `AbortController` timeout.

This PR adds `signal: AbortSignal.timeout(8000)` to that fetch (matching the existing 8s convention), so a slow or hanging response from YouTube now aborts after 8 seconds instead of relying on `fetch`'s default ~300s timeout.

## Why it helps

`getSubscriberCount()` is awaited directly in the render path of ~11 files: `app/page.js`, `app/about-me/page.js`, `app/faq/page.js`, `app/ai-consulting/page.js`, `app/podcasts/page.js`, `app/public-speaking/page.js`, `app/side-projects/page.js`, both `llms.txt`/`llms-full.txt` routes, `app/api/md/[...slug]/route.js`, and `app/api/ask/route.js`. A hang on this call could stall `next build` / ISR revalidation for minutes, or block a request, instead of failing fast into the existing (already well-written) `FALLBACK_SUBSCRIBERS` fallback three lines below. This is a reliability fix, not a feature — no visible copy changes.

## Files touched
- `lib/youtube.js`

## Build/lint status
- `npm ci` — clean
- `npm run build` — passes (confirmed the fallback path triggers correctly when the fetch fails, since this sandbox has no external network access)
- `npm run lint` — no warnings or errors

## TODOs left behind
None.

---

Purely technical, no visible copy change — auto-merging per the routine's merge rule.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QVJ81nTdPpgzpAbyvjSpYh)_