### PR TITLE
Close mobile nav on Escape and restore focus to the toggle button

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 
 const navLinks = [
@@ -39,6 +39,9 @@ export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const pathname = usePathname();
+  const toggleRef = useRef(null);
+  const panelRef = useRef(null);
+  const wasOpenRef = useRef(false);
 
   useEffect(() => {
     setIsOpen(false);
@@ -52,6 +55,31 @@ export default function Header() {
     window.addEventListener("scroll", onScroll);
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
+
+  // Every other overlay on the site (the entry gate, the floating chat panel)
+  // closes on Escape and hands focus back to whatever opened it. This one did
+  // neither: a keyboard visitor who opened the menu had no way to close it
+  // short of tabbing through all seven links, or reaching for the mouse.
+  useEffect(() => {
+    if (isOpen) {
+      wasOpenRef.current = true;
+      panelRef.current?.querySelector("a")?.focus();
+
+      function onKeyDown(event) {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setIsOpen(false);
+        }
+      }
+      document.addEventListener("keydown", onKeyDown);
+      return () => document.removeEventListener("keydown", onKeyDown);
+    }
+
+    if (wasOpenRef.current) {
+      wasOpenRef.current = false;
+      toggleRef.current?.focus();
+    }
+  }, [isOpen]);
 
   return (
     <header
@@ -83,6 +111,7 @@ export default function Header() {
             what carries that same state to a screen reader, and aria-controls
             ties the button to the panel it opens. */}
         <button
+          ref={toggleRef}
           type="button"
           onClick={() => setIsOpen(!isOpen)}
           className="lg:hidden relative z-40 w-8 h-6 flex flex-col justify-between"
@@ -109,6 +138,7 @@ export default function Header() {
         {isOpen && (
           <motion.div
             id="mobile-nav"
+            ref={panelRef}
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}


### PR DESCRIPTION
## What changed

`Header.js`'s mobile hamburger menu (`isOpen`/`#mobile-nav`) had no keyboard-close path and no focus management. Every other overlay on the site — the entry gate (`EntryGate.js`) and the floating chat panel (`FloatingChatWidget.js`) — already closes on Escape and hands focus back to whatever opened it; the mobile nav was the one exception.

This adds the same pattern:
- Opening the menu moves focus to its first link (matching the entry gate's focus-on-open behavior).
- Pressing Escape closes the menu.
- Closing (via Escape) returns focus to the hamburger toggle button.

This is a disclosure panel, not a modal (it pushes page content down rather than covering it), so it intentionally does **not** trap Tab inside it — that follows the WAI-ARIA APG disclosure pattern rather than the full focus-trap used by the entry gate's actual modal dialog.

## Why it helps

A keyboard-only visitor who opened the mobile nav previously had no way to close it short of tabbing through all seven links and back to the toggle, or reaching for a mouse — inconsistent with the rest of the site and a real friction point in a manual keyboard/axe accessibility audit.

## Files touched
- `app/components/Header.js`

## Build/lint status
- `npm ci` — clean
- `npm run build` — passes
- `npm run lint` — no warnings or errors
- Manually verified in a real headless-Chromium session at a mobile viewport: opening the menu focuses the first link ("AI Consulting"), Escape closes the panel, and focus returns to the "Open menu" button.

## TODOs left behind
None.

---

Purely technical accessibility fix, no visible copy change — auto-merging per the routine's merge rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_019jRmCkDaSUmMUfTQJ8MEUN)_