### PR TITLE
Add aria-current="page" to the active nav link in Header

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -23,6 +23,7 @@ function NavLink({ href, label, external, pathname, onClick }) {
       onClick={onClick}
       target={external ? "_blank" : undefined}
       rel={external ? "noopener noreferrer" : undefined}
+      aria-current={isActive ? "page" : undefined}
       className="group relative font-mono text-xs tracking-widest uppercase text-ink/70 hover:text-ink transition-colors"
     >
       {label}
@@ -160,6 +161,9 @@ export default function Header() {
                     href={link.href}
                     target={link.external ? "_blank" : undefined}
                     rel={link.external ? "noopener noreferrer" : undefined}
+                    aria-current={
+                      !link.external && pathname === link.href ? "page" : undefined
+                    }
                     onClick={() => setIsOpen(false)}
                     className="font-display italic text-2xl"
                   >


### PR DESCRIPTION
## What changed

`app/components/Header.js` renders the site's primary nav (desktop bar and mobile menu) on every route. It already computes `isActive` per link to draw a CSS underline under the current page, but that state was never exposed to assistive tech — only the underline signalled it, and only visually.

This adds `aria-current="page"` to the active link in both the desktop `NavLink` component and the mobile nav's `Link` elements (computed the same way: not an external link, and its `href` matches the current `pathname`).

## Why it helps

`aria-current="page"` is the ARIA Authoring Practices convention for marking the current item in a set of navigation links. Without it, a screen reader announces every nav link identically — a keyboard/screen-reader visitor has no way to tell which page they're already on from the nav itself, unlike a sighted visitor who sees the underline. This closes that gap on the site's most-visited, always-present surface, the same category as the earlier `rel=noopener` and focus-trap accessibility fixes.

No visible copy or layout changed — `aria-current` has no default visual styling and this codebase doesn't style it either.

## Files touched

- `app/components/Header.js`

## Build/lint status

- `npm ci` — clean
- `npm run build` — passes, all 35 routes generate successfully
- `npm run lint` — no ESLint warnings or errors

## TODO placeholders

None.

---

This is a purely technical accessibility fix — no visible copy, no new dependencies, no security surface, no personal information — auto-merging per the routine's rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_014TMfcXySvahBB4KFkkJ8gY)_