### PR TITLE
Fix manifest.js pointing at a deleted favicon.ico

### DIFF
--- a/app/manifest.js
+++ b/app/manifest.js
@@ -5,6 +5,12 @@ import { SITE_NAME } from "./seo";
 // colour and the name shown if a visitor adds the site to their home screen.
 // Colours mirror the Tailwind palette (`paper`/`ink`) rather than restating
 // them, so the manifest can't drift from what the site actually looks like.
+//
+// The icon points at `/icon.svg` — the same monogram Next.js already serves
+// for the browser tab via the `app/icon.svg` file convention. `app/favicon.ico`
+// was removed when that SVG replaced it, but this manifest kept pointing at
+// the now-deleted file, so the only icon a visitor's browser could find here
+// was a 404 and "Add to Home Screen" had nothing to show.
 export default function manifest() {
   return {
     name: SITE_NAME,
@@ -16,9 +22,9 @@ export default function manifest() {
     theme_color: "#F6F3EC",
     icons: [
       {
-        src: "/favicon.ico",
+        src: "/icon.svg",
         sizes: "any",
-        type: "image/x-icon",
+        type: "image/svg+xml",
       },
     ],
   };


### PR DESCRIPTION
## What changed

`app/manifest.js` (the Next.js web app manifest, served at `/manifest.webmanifest`) listed its only icon as:

```js
{ src: "/favicon.ico", sizes: "any", type: "image/x-icon" }
```

`app/favicon.ico` was deleted in a prior commit ("Replace default favicon with simple monogram icon") when `app/icon.svg` was added to replace it, but `app/manifest.js` was never updated to match. `/favicon.ico` now 404s — verified with `curl -sS -o /dev/null -w "%{http_code}" http://localhost/favicon.ico` → `404`, versus `/icon.svg` → `200`.

The practical effect: the web manifest's only icon entry is broken. A visitor using "Add to Home Screen" gets no valid icon, and a Lighthouse PWA/installability audit flags the manifest as invalid.

Fix: point the manifest icon at `/icon.svg` (`image/svg+xml`, `sizes: "any"`), the same monogram icon Next.js already serves for the browser tab via the `app/icon.svg` file convention. No new asset, no visual/brand change — it's the same icon, just referenced from a URL that actually resolves.

## Why it helps

This is bucket (c) from the task brief — a bug fix, not a feature or SEO change. It repairs a real 404 in the manifest that affects PWA installability checks and "Add to Home Screen" correctness.

## Files touched

- `app/manifest.js`

## Build/lint status

- `npm run build` — passes
- `npm run lint` — passes (`No ESLint warnings or errors`)
- Manually verified `/manifest.webmanifest` now serves `"icons":[{"src":"/icon.svg","sizes":"any","type":"image/svg+xml"}]` and that `/icon.svg` returns 200.

## TODO placeholders

None added.

This is a purely technical config/plumbing fix — no visible copy changed, no new dependency, no security-surface or personal-info change — so per the routine's rules I'm auto-merging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvqBKTAPfdkehsqJEPNtWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvqBKTAPfdkehsqJEPNtWR)_