### PR TITLE
Have the /ask widget crawl the AI consulting and FAQ pages

### DIFF
--- a/app/api/ask/route.js
+++ b/app/api/ask/route.js
@@ -3,6 +3,7 @@ import axios from "axios";
 import * as cheerio from "cheerio";
 import { NextResponse } from "next/server";
 import { getSubscriberCount } from "../../../lib/youtube";
+import { buildServices, credentials } from "../../content/consulting";
 
 const SITE_URL = "https://sarthaksavvy.com";
 // Pinned deliberately: the "~...-latest" alias resolves to a snapshot served by
@@ -79,6 +80,11 @@ LinkedIn: https://linkedin.com/in/sarthaksavvy
 }
 
 function fallbackContent(subscribers) {
+  const services = buildServices(subscribers)
+    .map((service) => `- ${service.title}: ${service.summary}`)
+    .join("\n");
+  const creds = credentials.map((c) => `- ${c.value}: ${c.label}`).join("\n");
+
   return `
 === Fallback Information about Sarthak Shrivastava ===
 Sarthak Shrivastava is an India-based founder, content creator, developer and AI consultant passionate about building and automating daily tasks.
@@ -95,6 +101,12 @@ Core Expertise:
 - AWS, Docker, AI/LLMs
 - Full-stack development
 - Content creation and education
+
+AI Consulting Services:
+${services}
+
+Credentials:
+${creds}
 
 Contact:
 - Website: https://sarthaksavvy.com
@@ -126,10 +138,12 @@ async function scrapeWebsiteContent() {
 
   const pages = [
     "/",
+    "/ai-consulting",
     "/about-me",
     "/side-projects",
     "/public-speaking",
     "/podcasts",
+    "/faq",
   ];
 
   const scrapePromises = pages.map(async (page) => {


### PR DESCRIPTION
## What changed

`scrapeWebsiteContent()` in `app/api/ask/route.js` builds the entire knowledge base the "Ask anything about Sarthak" widget (`FloatingChatWidget.js`, `/ask`) answers from, by crawling a fixed list of pages:

```js
const pages = [
  "/",
  "/about-me",
  "/side-projects",
  "/public-speaking",
  "/podcasts",
];
```

`/ai-consulting` was missing from that list — despite being the site's second-highest-priority indexed route (`app/routes.js`, priority `0.9`, second only to `/`) and the only page that describes the actual consulting services (`buildServices()` in `app/content/consulting.js`: LLM features in production, AI automation, deployment/monitoring, team enablement). `/faq` was also missing.

This adds both to the crawl list:

```js
const pages = [
  "/",
  "/ai-consulting",
  "/about-me",
  "/side-projects",
  "/public-speaking",
  "/podcasts",
  "/faq",
];
```

It also extends `fallbackContent()` — the hand-written backup the route serves when every live page-scrape fails — with the same services list and credentials, sourced directly from `buildServices()`/`credentials` in `app/content/consulting.js` rather than new text, so the degraded path doesn't strand the same question.

## Why it helps

This is a bug fix (bucket c), not a feature or copy change. The widget's advertised purpose is answering questions about Sarthak, on a site whose stated purpose is AI consulting — but the one page describing what that consulting actually covers was never part of what the model sees. A visitor asking "What AI consulting services does he offer?" — arguably the single most likely question for this exact tool on this exact site — got an answer built from zero information about it, and the model would either hedge or guess. This closes that gap using only content the site already publishes.

## Files touched

- `app/api/ask/route.js`

## Build/lint status

- `npm ci` — clean
- `npm run build` — passes, all 35 routes generate successfully
- `npm run lint` — no ESLint warnings or errors

## TODO placeholders

None.

---

This is a purely technical fix to the /ask API's internal data source — no visible copy changed (the fallback text quotes the site's own existing consulting copy verbatim rather than introducing anything new), no new dependency, no security surface, no personal information. Auto-merging per the routine's rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpnbugBttRj8fPKkCTRb1p

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpnbugBttRj8fPKkCTRb1p)_