### PR TITLE
Add a Content-Security-Policy response header

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,42 @@
+// The only third-party script the site loads is Google's gtag.js, and the
+// only inline script is the small config snippet that calls it (layout.js).
+// Everything else — images, fonts, the /ask fetches — is same-origin, so the
+// policy below can name Google explicitly and default everything else to
+// 'self' instead of allowing arbitrary origins.
+//
+// 'unsafe-inline' stays on script-src and style-src because the gtag config
+// snippet is an inline <script> and React's `style={{...}}` props render as
+// inline `style=""` attributes throughout the motion components — replacing
+// either with nonces would need per-request middleware this app doesn't have.
+// The policy still blocks the two things that matter most for this site: a
+// script tag pointed at an attacker-controlled domain, and the page being
+// framed by someone else's site.
+//
+// Next's dev server evals its own HMR bundles, which a production CSP would
+// block — so 'unsafe-eval' is scoped to development only.
+const isDev = process.env.NODE_ENV !== "production";
+const csp = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline' ${isDev ? "'unsafe-eval' " : ""}https://www.googletagmanager.com`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
 // Baseline response headers the app never set on its own. None of these
 // depend on how a page is rendered, so applying them to every route is safe:
 // there is no framing, no cross-origin embedding and no use of camera/mic/
 // geolocation anywhere on the site for these to interfere with.
 const securityHeaders = [
+  // Restricts every resource the page can load or connect to. See the
+  // comment above for why 'unsafe-inline' is still needed and what stays
+  // blocked despite it.
+  { key: "Content-Security-Policy", value: csp },
   // Stops a browser from guessing a response's MIME type from its content,
   // which is how a misconfigured upload or an old browser can be tricked
   // into executing something served as plain text or an image.


### PR DESCRIPTION
NEEDS APPROVAL: this touches security response headers.

## What changed
`next.config.mjs` gains a `Content-Security-Policy` entry alongside the existing `securityHeaders` (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, Strict-Transport-Security). It was the one major browser security header conspicuously missing from an otherwise comprehensive list.

## Why it helps
CSP is the header that actually stops an injected or compromised script from loading code off an attacker-controlled domain — the other headers cover MIME sniffing, clickjacking, referrer leakage, and transport, but nothing previously restricted *what the page is allowed to load or connect to*.

I audited the site's actual external surface before writing the policy (`grep`'d every `fetch(`, image `src`, and `<Script>` in `app/`): the only third-party resource loaded anywhere is Google's `gtag.js` plus the inline snippet in `app/layout.js` that configures it. Everything else — images, fonts (self-hosted via `next/font`), the `/ask` API calls — is same-origin. So the policy:
- Defaults everything to `'self'`.
- Explicitly allow-lists `https://www.googletagmanager.com` (script) and the Google Analytics collection domains (`connect-src`).
- Sets `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, and `frame-ancestors 'none'` (a modern equivalent of the existing `X-Frame-Options: DENY`).
- Keeps `'unsafe-inline'` on `script-src` and `style-src`, because the gtag config snippet is an inline `<script>` and React's `style={{...}}` props (used throughout `app/components/motion/*`) render as inline `style=""` attributes. Removing it would require per-request nonce middleware, which this app doesn't have — a good follow-up if it's ever worth the added complexity.
- Scopes `'unsafe-eval'` to development only (`process.env.NODE_ENV !== "production"`), since Next's dev server evals its own HMR bundles; production ships without it.

This still blocks the two things that matter most for a static/mostly-server-rendered site like this: a script tag pointed at an attacker's domain, and the page being framed by someone else's site — while allow-listing nothing beyond what the site actually uses today.

## Files touched
- `next.config.mjs` — added the `csp` policy string and one new header entry.

## Build/lint status
- `npm ci` — clean install.
- `npm run build` — passes (the `[youtube] channel page fetch failed with status 403, using fallback` lines are the existing build-time YouTube subscriber-count fallback, unrelated to this change, and occur in this sandboxed network environment regardless).
- `npm run lint` — no warnings or errors.
- Manually started the built production server (`npm run start`) and confirmed with `curl -I` that the header is sent and renders correctly (no `'unsafe-eval'` in the production script-src).

## TODO placeholders
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyNLFAdt5LrnJuTzhYKgot

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyNLFAdt5LrnJuTzhYKgot)_