### PR TITLE
Set a real minimumCacheTTL for the image optimizer

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -37,6 +37,19 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  images: {
+    // Next's image optimizer defaults to caching an optimized image for only
+    // 60 seconds, which is fine for a feed of constantly-changing thumbnails
+    // but not for a site whose photos (the portrait, project screenshots,
+    // podcast art) are static assets that rarely change. Every /images/* file
+    // on this site goes through <ClientImage>, i.e. next/image, so the
+    // 60-second default means the optimizer re-derives and re-serves the same
+    // resized image on almost every request instead of letting a CDN or
+    // browser hold onto it. A month is long enough to matter for repeat
+    // visits and short enough that a swapped project screenshot is not stuck
+    // stale for a meaningful stretch of time.
+    minimumCacheTTL: 2678400,
+  },
   // Plain-markdown mirrors of every page, for LLMs and answer engines. The
   // handler lives under /api/md/... because that is where a catch-all route
   // can be defined, but /api/ is disallowed in robots.txt — so the URL that


### PR DESCRIPTION
## What changed

`next.config.mjs` gains an `images.minimumCacheTTL` of 2,678,400 seconds (31 days). Next.js's built-in image optimizer defaults this to 60 seconds — a value meant for feeds of constantly-changing thumbnails, not a personal site whose photos (portrait, five project screenshots, podcast cover art — 83MB total under `public/images`) are static and go through `next/image` via `ClientImage.js` on essentially every page.

## Why it helps (Core Web Vitals)

At the 60-second default, the optimizer re-derives and re-serves the same resized/re-encoded image on almost every request instead of letting a CDN or browser cache hold onto it — this is exactly what PageSpeed Insights flags as "serve images with efficient cache policy," and it directly affects LCP for repeat visits (the hero portrait and project screenshots are above-the-fold/likely-LCP candidates on several routes). 31 days is long enough to actually matter for cache hit rate, short enough that a swapped project screenshot doesn't stay stale for a meaningful stretch.

This is scoped to `images.minimumCacheTTL` only — it does not touch the existing `headers()`/`securityHeaders` block in the same file, which is unrelated response-header configuration.

## Files touched

- `next.config.mjs`

## Build/lint status

- `npm ci` — clean
- `npm run build` — passes, all 35 routes generate successfully
- `npm run lint` — no ESLint warnings or errors

## TODO placeholders

None.

---

Pure technical, non-visible perf config — no copy, positioning, dependencies, or security-header changes. Auto-merging per the routine's rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qbLMXdrimeeutQ5ktTgUu

---
_Generated by [Claude Code](https://claude.ai/code/session_012qbLMXdrimeeutQ5ktTgUu)_