### PR TITLE
Add YouTube to the footer's social icon row

### DIFF
--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { socialIcons } from "./SocialIcons";
+import { YOUTUBE_URL } from "../content/profile";
 
 const links = [
   { href: "/ai-consulting", label: "AI Consulting" },
@@ -26,6 +27,11 @@ const socials = [
     href: "https://github.com/sarthaksavvy",
     icon: "github",
     label: "Sarthak Shrivastava on GitHub",
+  },
+  {
+    href: YOUTUBE_URL,
+    icon: "youtube",
+    label: "Sarthak Shrivastava on YouTube",
   },
   {
     href: "https://instagram.com/sarthaksavvy",

--- a/app/components/SocialIcons.js
+++ b/app/components/SocialIcons.js
@@ -48,9 +48,18 @@ export function XIcon(props) {
   );
 }
 
+export function YoutubeIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" {...base} {...props}>
+      <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+    </svg>
+  );
+}
+
 export const socialIcons = {
   linkedin: LinkedinIcon,
   github: GithubIcon,
   instagram: InstagramIcon,
   x: XIcon,
+  youtube: YoutubeIcon,
 };


### PR DESCRIPTION
NEEDS APPROVAL: this touches social links — a visible, site-wide statement of which profiles Sarthak points visitors to.

## What changed
- `app/components/SocialIcons.js`: added a `YoutubeIcon` component (Simple Icons' CC0 glyph), matching the existing inline-SVG style (`fill="currentColor"`, `aria-hidden`, `focusable="false"`) of the other icons, and registered it in `socialIcons`.
- `app/components/Footer.js`: added a YouTube entry to the `socials` array (using `YOUTUBE_URL` imported from `content/profile.js` rather than a hardcoded string), positioned right after LinkedIn/GitHub to match the order YouTube appears in `SOCIAL_PROFILES` in `content/profile.js`.

## Why it helps
`YOUTUBE_URL` was already declared in `content/profile.js`, already included in `SAME_AS` (the schema.org `sameAs` list emitted on every page), and already linked from the header nav — but the footer's icon row, which mirrors those same social profiles on every page of the site, silently left it out. LinkedIn, GitHub, Instagram and X all got an icon; YouTube, arguably Sarthak's single biggest credibility signal as an AI consultant and educator (156K+ subscribers, headlined right in the hero as "Youtube Subs"), did not. This is a feature/UX fix: it gives visitors on every page a direct, recognizable path to the channel that backs up his "content creator" and "educator" positioning, and it brings the footer in line with the social profiles the site already declares to search engines and assistants via structured data.

No visible copy changed elsewhere, no new dependency, no existing link removed or altered — this only adds one icon using a URL the codebase already treats as canonical.

## Files touched
- `app/components/SocialIcons.js`
- `app/components/Footer.js`

## Build/lint status
- `npm run build` — passed
- `npm run lint` — passed (no warnings or errors)

## TODOs left behind
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zskDFCccVkUz4YorWC6ns

---
_Generated by [Claude Code](https://claude.ai/code/session_018zskDFCccVkUz4YorWC6ns)_