### PR TITLE
Add an apple-touch-icon so iOS home screen shows the site mark

### DIFF
--- a/app/apple-icon.js
+++ b/app/apple-icon.js
@@ -1,0 +1,39 @@
+import { ImageResponse } from "next/og";
+
+// `app/icon.svg` already gives the browser tab its monogram via Next's file
+// convention, but iOS Safari does not read that: "Add to Home Screen" only
+// looks for an `apple-touch-icon` link, and without one it falls back to a
+// screenshot of whatever was on screen — usually a crop of body text, not the
+// site's mark. This file is the same convention for that icon: Next renders
+// it once at build time and wires up the `<link rel="apple-touch-icon">`
+// automatically, no manual tag needed.
+//
+// Same mark and colours as `app/icon.svg`, redrawn at PNG size and without
+// its own corner rounding — iOS applies its own mask on top of whatever
+// square it's given, so a pre-rounded source only fights that mask.
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#111111",
+          fontFamily: "Arial, Helvetica, sans-serif",
+          fontSize: 100,
+          fontWeight: 700,
+          color: "#ffffff",
+        }}
+      >
+        S
+      </div>
+    ),
+    { ...size }
+  );
+}


### PR DESCRIPTION
## What changed
- Added `app/apple-icon.js`, using Next's file-convention icon generation (`ImageResponse` from `next/og`) to render the same "S" monogram already used for the browser-tab favicon (`app/icon.svg`) as a 180×180 PNG at build time.

## Why it helps
`app/icon.svg` already gives the browser tab a monogram via Next's file convention, but iOS Safari doesn't read that file: "Add to Home Screen" only looks for an `apple-touch-icon` link tag, and without one it falls back to a screenshot of whatever content happened to be on screen — usually a crop of body text, not the site's mark. This adds the matching file-convention icon so Next automatically emits the `<link rel="apple-touch-icon">` tag and iOS visitors who save the site get the actual brand mark instead of a random content screenshot. No manual `<head>` edit needed — Next wires the tag up from the file's presence alone.

The icon reuses the exact same colors and glyph as the existing `app/icon.svg` (black `#111111` background, white "S", same font) — no new visual identity introduced. It's deliberately not pre-rounded: iOS applies its own corner mask to home-screen icons, so a square source is standard practice.

## Files touched
- `app/apple-icon.js` (new)

## Build/lint status
- `npm ci` — passed
- `npm run build` — passed (new `/apple-icon` static route appears in the build output, confirmed by rendering the produced PNG — a clean 180×180 image of the monogram)
- `npm run lint` — passed, no warnings or errors

## TODOs left behind
None.

---

This is a purely technical, non-public-facing change: it doesn't touch security, personal information, pricing, testimonials, dependencies, or deploy config, and no visible page copy changed (the new file reuses the site's existing icon design, doesn't introduce a new one). Per the routine's rules, this is being auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeQxrZZmtmyLYeWsQSkCXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeQxrZZmtmyLYeWsQSkCXk)_