### PR TITLE
Add 192x192 and 512x512 PNG icons to the web manifest

### DIFF
--- a/app/icon-192.png/route.js
+++ b/app/icon-192.png/route.js
@@ -1,0 +1,11 @@
+import { monogramIcon } from "../../lib/monogramIcon";
+
+// Referenced by app/manifest.js. The manifest's `icons` array needs a real
+// bitmap at 192x192 — the size Android's "Add to Home Screen" and a
+// Lighthouse PWA installability audit both look for — which the SVG favicon
+// alone does not satisfy on every platform.
+export const dynamic = "force-static";
+
+export function GET() {
+  return monogramIcon(192);
+}

--- a/app/icon-512.png/route.js
+++ b/app/icon-512.png/route.js
@@ -1,0 +1,10 @@
+import { monogramIcon } from "../../lib/monogramIcon";
+
+// Referenced by app/manifest.js. 512x512 is the larger of the two sizes a
+// Lighthouse PWA installability audit expects a manifest icon set to cover,
+// used for splash screens and higher-density home-screen icons.
+export const dynamic = "force-static";
+
+export function GET() {
+  return monogramIcon(512);
+}

--- a/app/manifest.js
+++ b/app/manifest.js
@@ -11,6 +11,13 @@ import { SITE_NAME } from "./seo";
 // was removed when that SVG replaced it, but this manifest kept pointing at
 // the now-deleted file, so the only icon a visitor's browser could find here
 // was a 404 and "Add to Home Screen" had nothing to show.
+//
+// The SVG alone passes in most browsers, but Android's install prompt and a
+// Lighthouse PWA installability audit both look for a bitmap in the manifest
+// at 192x192 and 512x512 specifically — an SVG-only icon set fails that
+// check even though it renders fine. `/icon-192.png` and `/icon-512.png` are
+// the same mark rendered at build time (see app/icon-192.png/route.js and
+// app/icon-512.png/route.js) so there is a real bitmap at both sizes.
 export default function manifest() {
   return {
     name: SITE_NAME,
@@ -25,6 +32,16 @@ export default function manifest() {
         src: "/icon.svg",
         sizes: "any",
         type: "image/svg+xml",
+      },
+      {
+        src: "/icon-192.png",
+        sizes: "192x192",
+        type: "image/png",
+      },
+      {
+        src: "/icon-512.png",
+        sizes: "512x512",
+        type: "image/png",
       },
     ],
   };

--- a/lib/monogramIcon.js
+++ b/lib/monogramIcon.js
@@ -1,0 +1,30 @@
+import { ImageResponse } from "next/og";
+
+// The same mark and colours as `app/icon.svg` and `app/apple-icon.js`,
+// redrawn at whatever size a caller needs. Shared here because the manifest
+// needs PNG icons at specific sizes (192 and 512) that the SVG favicon and
+// the single-size apple-touch-icon do not cover, and a Lighthouse PWA
+// installability audit checks for exactly those two.
+export function monogramIcon(size) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#111111",
+          fontFamily: "Arial, Helvetica, sans-serif",
+          fontSize: Math.round(size * 0.56),
+          fontWeight: 700,
+          color: "#ffffff",
+        }}
+      >
+        S
+      </div>
+    ),
+    { width: size, height: size }
+  );
+}


### PR DESCRIPTION
## What changed
- Added `app/icon-192.png/route.js` and `app/icon-512.png/route.js`, two build-time routes (same `/dotted-path/route.js` pattern already used for `robots.txt` and `llms.txt`) that render the site's monogram as a PNG via `ImageResponse`, at 192x192 and 512x512.
- Added `lib/monogramIcon.js`, a small shared helper the two routes call with their target size, so the mark isn't redrawn twice.
- Updated `app/manifest.js`'s `icons` array to include both new PNGs alongside the existing `/icon.svg` entry.

## Why it helps
The manifest previously listed only an SVG icon (`sizes: "any"`). Most modern desktop browsers accept that, but Android's "Add to Home Screen" install prompt and a Lighthouse PWA installability audit specifically check the manifest for a bitmap icon at 192x192 and at 512x512 — an SVG-only icon set fails that check even though the icon renders fine everywhere else. This closes that gap without introducing a second visual identity: both PNGs reuse the exact same mark, colors (`#111111` background, white "S", same font) and un-rounded square as the existing `app/icon.svg` and `app/apple-icon.js` (the corner rounding for `icon.svg` and OS-level masking for the touch icon are applied by the platform, not baked into the source image — same reasoning `apple-icon.js` already documents).

## Files touched
- `app/manifest.js`
- `app/icon-192.png/route.js` (new)
- `app/icon-512.png/route.js` (new)
- `lib/monogramIcon.js` (new)

## Build/lint status
- `npm ci` — passed
- `npm run build` — passed; `/icon-192.png` and `/icon-512.png` both appear as new static routes in the build output, and the produced files were verified with `file` to be genuine 192x192 and 512x512 PNGs
- `npm run lint` — passed, no warnings or errors

## TODOs left behind
None.

---

This is a purely technical, non-public-facing change: it doesn't touch security, personal information, pricing, testimonials, dependencies, or deploy config, and no visible page copy changed — the new icons are meta/manifest plumbing only, using the site's existing icon design. Per the routine's rules, this is being auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmHxmCoywWJSmYLu5UyjV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmHxmCoywWJSmYLu5UyjV4)_