### PR TITLE
Fix duplicate and unnamed links on the side-projects grid

### DIFF
--- a/app/components/motion/DissolveImage.js
+++ b/app/components/motion/DissolveImage.js
@@ -33,7 +33,13 @@ export default function DissolveImage({ src, alt, className = "" }) {
         sizes="(max-width: 768px) 100vw, 50vw"
         className="object-cover grayscale-[0.6] scale-105 transition-transform duration-700"
       />
+      {/* The same photo again, revealed through a mask that follows the
+          cursor — a second copy of a picture that is already on screen, not a
+          second picture. Described it would be announced twice in a row, and
+          where this sits inside a link that is the link's whole accessible
+          name: "Ginger Ginger". Same treatment as ParticleImage's hover layer. */}
       <div
+        aria-hidden="true"
         className="absolute inset-0 transition-opacity duration-300"
         style={{
           opacity: hovering ? 1 : 0,
@@ -43,7 +49,7 @@ export default function DissolveImage({ src, alt, className = "" }) {
       >
         <Image
           src={src}
-          alt={alt}
+          alt=""
           fill
           sizes="(max-width: 768px) 100vw, 50vw"
           className="object-cover"

--- a/app/side-projects/page.js
+++ b/app/side-projects/page.js
@@ -113,7 +113,18 @@ export default async function SideProjects() {
                   i % 2 === 1 ? "md:mt-12" : ""
                 }`}
               >
-                <Link href={project.projectLink}>
+                {/* Clicking the screenshot goes where the heading link
+                    directly beneath it goes, under the same name. Two links to
+                    one destination is one extra Tab stop and one extra
+                    "AudioBolo, link" per card for anyone listing the page's
+                    links — fifteen entries for five projects. The picture stays
+                    clickable for a mouse; the heading is the one that is
+                    reachable and announced. */}
+                <Link
+                  href={project.projectLink}
+                  aria-hidden="true"
+                  tabIndex={-1}
+                >
                   <div className="h-64 relative bg-line">
                     <DissolveImage src={project.image} alt={project.name} className="h-full w-full" />
                   </div>
@@ -150,10 +161,17 @@ export default async function SideProjects() {
                     </ul>
                   </div>
 
+                  {/* "View Details" and "Visit Project" appear five times each
+                      on this page, and a links list or a link read on its own
+                      carries no card around it to say which project it belongs
+                      to. The visible label stays as it is; the accessible name
+                      names the project, and says which of the two leaves the
+                      site. */}
                   <div className="flex flex-wrap gap-3">
                     <MagneticButton
                       as={Link}
                       href={project.projectLink}
+                      aria-label={`View details about ${project.name}`}
                       className="inline-flex items-center gap-2 bg-ink text-paper px-6 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:bg-accent transition-colors"
                     >
                       View Details
@@ -164,6 +182,7 @@ export default async function SideProjects() {
                       href={project.link}
                       target="_blank"
                       rel="noopener noreferrer"
+                      aria-label={`Visit the ${project.name} website (opens in a new tab)`}
                       className="inline-flex items-center gap-2 border border-ink/20 px-6 py-3 rounded-full font-mono text-xs tracking-widest uppercase hover:border-ink transition-colors"
                     >
                       Visit Project


### PR DESCRIPTION
## What changed

Three accessibility defects on `/side-projects`, all in the project card grid.

**1. The screenshot was a second link to the page the heading already links to.**
Each card wrapped its image in its own `<Link href={project.projectLink}>`, and
the `<h2>` directly beneath it links to the same URL with the same name. That is
an extra Tab stop and an extra identical entry per card — 15 links for 5
projects where 10 would do. The picture stays clickable for a mouse, but is now
`aria-hidden` + `tabIndex={-1}` so the heading is the one that is reachable and
announced.

**2. `DissolveImage` announced its photo twice.**
The component renders the same image twice — a resting layer and a sharp hover
reveal masked to the cursor — and both carried `alt={project.name}`. Inside the
image link that made the link's whole accessible name *"AudioBolo AudioBolo"*.
The hover layer is a second copy of a picture already on screen, not a second
picture, so it is now marked decorative. `ParticleImage`'s hover layer already
does exactly this (`alt=""`); `DissolveImage` was the outlier.

**3. "View Details" and "Visit Project" appear five times each with no context.**
A links list, or a link read on its own, carries no card around it to say which
project it belongs to. Visible labels are unchanged; the accessible names now
name the project and flag the one that leaves the site.

## Why it helps

Screen reader and keyboard users get one clearly named link per destination
instead of a repeated, ambiguous set. Repetitive and generic link text is
WCAG 2.4.4 (Link Purpose), and the duplicate adjacent link is the classic
"redundant link" pattern axe and Lighthouse both flag.

It also matches conventions the repo already states for itself. `app/page.js`
carries the comment *"Descriptive link text, not 'read more' … six links all
reading 'learn more' teach it nothing"*, and `Marquee` already hides its
duplicated visual copy from assistive tech for the same reason as change 2.

No visible copy, layout, styling, or animation changes — every edit is an
accessibility attribute or an `alt` on a layer that duplicates a visible one.

## Files touched

- `app/side-projects/page.js` — image link removed from the a11y tree; `aria-label` on both card buttons
- `app/components/motion/DissolveImage.js` — hover layer marked decorative

## Build / lint status

- `npm ci` — clean
- `npm run build` — passes, all routes prerender as before
- `npm run lint` — `✔ No ESLint warnings or errors`

Verified against the prerendered `/side-projects` HTML: 5 hidden image links
(one per card), 5 decorative overlays with `alt=""`, and each project name now
appears once as an `alt` rather than twice.

## TODO placeholders

None. No new placeholders, and none of the existing ones
(`engagementFormats`, `caseStudies` in `app/content/consulting.js`) are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nd3s2fC393AkTWp64Stcn7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd3s2fC393AkTWp64Stcn7)_