### PR TITLE
Add a route-level loading UI

### DIFF
--- a/app/loading.js
+++ b/app/loading.js
@@ -1,0 +1,26 @@
+// Every route's page component is an async server component that awaits a
+// live YouTube fetch (see lib/youtube.js) before it can render anything —
+// cached for 24h on success, but a cold cache or a slow upstream response
+// otherwise leaves the browser on a blank tab with no feedback at all. This
+// is the Next.js file convention for exactly that gap: it streams in
+// immediately on navigation and is swapped out the moment the page segment
+// below it is ready, so a visitor always sees something within a paint.
+export default function Loading() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="py-32 flex items-center justify-center min-h-[60vh]"
+    >
+      <div className="flex items-center gap-3 text-muted">
+        <span
+          aria-hidden="true"
+          className="w-4 h-4 border-2 border-accent border-t-transparent rounded-full animate-spin"
+        />
+        <span className="font-mono text-xs tracking-widest uppercase">
+          Loading
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What changed
Adds `app/loading.js`, using the [Next.js App Router `loading.js` file convention](https://nextjs.org/docs/app/api-reference/file-conventions/loading) — a Suspense fallback shown automatically while a route segment is loading.

## Why it helps
Every route's `page.js` in this app (`/`, `/about-me`, `/ai-consulting`, `/side-projects`, `/podcasts`, etc.) is an `async` server component that `await`s `getSubscriberCount()` (`lib/youtube.js`) before it can render anything. That fetch is revalidated every 24h and usually served from cache, but on a cold cache, a slow upstream response, or the first request after a deploy, the browser was left on a blank tab with zero feedback during navigation — nothing painted until the whole page resolved.

`loading.js` closes that gap: Next.js streams it in immediately on navigation and swaps it for the real page the instant that page's data is ready. This is a Core Web Vitals / perceived-performance fix, not a visual redesign — it reuses the exact spinner markup and classes already shipped in `app/ask/page.js`'s own `Suspense` fallback, so it matches the site's existing loading-state pattern rather than introducing a new one. It carries `role="status"` and `aria-live="polite"` so the state change is announced to screen readers, consistent with the accessibility work already present elsewhere in the app (e.g. the `/ask` page's own live regions).

No page copy, positioning, or content changed — this is purely a new transient loading state that only ever appears for the fraction of a second before real content streams in.

## Files touched
- `app/loading.js` (new)

## Build/lint status
- `npm ci` — clean install
- `npm run build` — passed (38/38 pages generated)
- `npm run lint` — no warnings or errors

## TODOs left behind
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HASkAmkGb47CHcebTh59bS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HASkAmkGb47CHcebTh59bS)_