### PR TITLE
Read Footer/Header contact links from content/profile.js constants

### DIFF
--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { socialIcons } from "./SocialIcons";
+import { EMAIL } from "../content/profile";
 
 const links = [
   { href: "/ai-consulting", label: "AI Consulting" },
@@ -49,10 +50,10 @@ export default function Footer() {
               {"// LET'S BUILD SOMETHING"}
             </p>
             <a
-              href="mailto:hello@sarthaksavvy.com"
+              href={`mailto:${EMAIL}`}
               className="font-display italic text-4xl sm:text-6xl hover:text-accent transition-colors"
             >
-              hello@sarthaksavvy.com
+              {EMAIL}
             </a>
           </div>
           <div className="flex gap-3 flex-wrap items-start">

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -4,14 +4,15 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { COURSES_URL, YOUTUBE_URL } from "../content/profile";
 
 const navLinks = [
   { href: "/ai-consulting", label: "AI Consulting" },
   { href: "/podcasts", label: "Podcasts" },
   { href: "/public-speaking", label: "Public Speaking" },
   { href: "/side-projects", label: "Side Projects" },
-  { href: "https://youtube.com/@sarthaksavvy", label: "Youtube", external: true },
-  { href: "https://courses.sarthaksavvy.com/", label: "Courses", external: true },
+  { href: YOUTUBE_URL, label: "Youtube", external: true },
+  { href: COURSES_URL, label: "Courses", external: true },
   { href: "/about-me", label: "About Me" },
 ];
 


### PR DESCRIPTION
## What changed
- `app/components/Footer.js`: the "hello@sarthaksavvy.com" mailto link and its visible label were both hardcoded string literals. Both now read from `EMAIL`, exported from `app/content/profile.js`.
- `app/components/Header.js`: the "Youtube" and "Courses" entries in `navLinks` hardcoded `https://youtube.com/@sarthaksavvy` and `https://courses.sarthaksavvy.com/`. Both now read from `YOUTUBE_URL` and `COURSES_URL`, exported from the same file.

## Why it helps
`content/profile.js`'s own header comment explains the rule this repo already follows: three consumers — the rendered pages, the schema.org graph, and the markdown/llms.txt mirrors — read every fact about Sarthak from that one file specifically so they can never disagree. A hardcoded string in a component is exactly the drift that guard exists to prevent; PR #51 fixed the same pattern on the side-projects and public-speaking pages, but Footer.js and Header.js — the two components rendered on every single route — still carried their own copies.

Today every value is byte-identical to the constant it duplicates, so nothing rendered changes. The value is that it no longer *can* drift silently: if the booking/courses URL or contact email is ever updated in `profile.js` (the file the schema.org markup and the AI-crawler-facing markdown mirrors already trust), the site-wide header and footer now update with it instead of needing a second, easy-to-miss edit.

This is a pure refactor — no visible copy, links, or destination URLs changed.

## Files touched
- `app/components/Footer.js`
- `app/components/Header.js`

## Build/lint status
- `npm ci` — clean install
- `npm run build` — passed (the `[youtube] channel page fetch failed with status 403, using fallback` lines are the existing build-time YouTube subscriber-count fallback in this sandboxed network environment, unrelated to this change)
- `npm run lint` — no warnings or errors

## TODOs left behind
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vry8s6d9vaUci1Q96HmEP

---
_Generated by [Claude Code](https://claude.ai/code/session_019vry8s6d9vaUci1Q96HmEP)_