### PR TITLE
Read Footer's social icon hrefs from content/profile.js

### DIFF
--- a/app/components/Footer.js
+++ b/app/components/Footer.js
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { socialIcons } from "./SocialIcons";
-import { EMAIL } from "../content/profile";
+import { EMAIL, SOCIAL_PROFILES } from "../content/profile";
 
 const links = [
   { href: "/ai-consulting", label: "AI Consulting" },
@@ -17,28 +17,26 @@ const links = [
 // The icon is the whole of each link, so its alt text is the only accessible
 // name the link has. "x" on its own tells a screen reader nothing; the label
 // below is what gets read out instead.
-const socials = [
-  {
-    href: "https://linkedin.com/in/sarthaksavvy",
-    icon: "linkedin",
-    label: "Sarthak Shrivastava on LinkedIn",
-  },
-  {
-    href: "https://github.com/sarthaksavvy",
-    icon: "github",
-    label: "Sarthak Shrivastava on GitHub",
-  },
-  {
-    href: "https://instagram.com/sarthaksavvy",
-    icon: "instagram",
-    label: "Sarthak Shrivastava on Instagram",
-  },
-  {
-    href: "https://x.com/sarthaksavvy",
-    icon: "x",
-    label: "Sarthak Shrivastava on X",
-  },
+//
+// Hrefs come from content/profile.js's SOCIAL_PROFILES — the same list the
+// schema.org `sameAs` graph is built from — rather than being retyped here.
+// A profile URL that changes in one of the two places and not the other is
+// exactly the kind of drift content/profile.js exists to prevent.
+const FOOTER_SOCIAL_ICONS = [
+  { profileLabel: "LinkedIn", icon: "linkedin" },
+  { profileLabel: "GitHub", icon: "github" },
+  { profileLabel: "Instagram", icon: "instagram" },
+  { profileLabel: "X (Twitter)", icon: "x", displayName: "X" },
 ];
+
+const socials = FOOTER_SOCIAL_ICONS.map(({ profileLabel, icon, displayName }) => {
+  const profile = SOCIAL_PROFILES.find((p) => p.label === profileLabel);
+  return {
+    href: profile.href,
+    icon,
+    label: `Sarthak Shrivastava on ${displayName ?? profileLabel}`,
+  };
+});
 
 export default function Footer() {
   return (


### PR DESCRIPTION
NEEDS APPROVAL: this touches the footer's social links — the rule treats any change to social links as a public-image item even though the URLs themselves are unchanged.

## What changed
`app/components/Footer.js`: the `socials` array (LinkedIn, GitHub, Instagram, X icons) now reads its `href` for each icon from `SOCIAL_PROFILES` in `app/content/profile.js`, instead of retyping the four URLs directly in the component.

## Why it helps
`content/profile.js` already declares `SOCIAL_PROFILES` as the single source of truth for Sarthak's social URLs — it's what the `sameAs` field in the site's schema.org `Person`/`WebSite` markup is built from, and its own docstring is explicit about why: "Nothing in this file may be a claim that is not already visible somewhere... A single exported object is what makes the three copies the same copy." The footer's icon row had its own hand-typed copies of the same four URLs, which is exactly the kind of drift that comment warns about — if a handle ever changes, updating `profile.js` alone would silently leave the footer pointing at the old one. This is the same category of fix as #51/#52 (deduping hardcoded contact/mailto links against `content/profile.js`), just for the one spot they didn't reach.

This is a refactor only: hrefs, icon choice, order and the rendered `aria-label` text are all identical to what was there before — verified by reading the generated `socials` array against the original hardcoded one.

## Files touched
- `app/components/Footer.js`

## Build/lint status
- `npm ci` — clean install
- `npm run build` — passed, all 38 routes generated
- `npm run lint` — no warnings or errors

## TODOs left behind
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpKF1PS5pmAW7EKerUyurw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpKF1PS5pmAW7EKerUyurw)_